### PR TITLE
add requirement to configureController(c,m) that m is not 0

### DIFF
--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -51,11 +51,10 @@ contract Controller is Ownable {
 
     /**
      * @dev set the controller of a particular _worker
-     * To disable the controller, call configureController(_controller, address(0))
-     * Since a controller manages a single worker, assigning it address(0) is equivalent to
-     * removing _controller from the list of active controllers.
+     * Argument _worker must not be 0x00, call removeController(_controller) instead.
      */
     function configureController(address _controller, address _worker) onlyOwner public returns (bool) {
+        require(_worker != address(0));
         controllers[_controller] = _worker;
         emit ControllerConfigured(_controller, _worker);
         return true;

--- a/verification/Spreadsheets/MINTp0 - ArgumentTests.csv
+++ b/verification/Spreadsheets/MINTp0 - ArgumentTests.csv
@@ -5,7 +5,7 @@ Ownable.sol,transferOwnership,newOwner == owner,arg002,arg002 transferOwnership(
 Controller.sol,configureController,newController == 0,arg003,"arg003 configureController(0, M) works"
 Controller.sol,configureController,newController == msg.sender,arg004,"arg004 configureController(msg.sender, M) works"
 Controller.sol,configureController,newController == newMinter,arg005,"arg005 configureController(M, M) works"
-Controller.sol,configureController,newMinter == 0,arg006,"arg006 configureController(C, 0) works"
+Controller.sol,configureController,newMinter == 0,arg006,"arg006 configureController(C, 0) throws"
 Controller.sol,removeController,newController == 0,arg007,arg007 removeController(0) works
 MintController.sol,setMinterManager,newMinterManager = 0,arg008,arg008 setMinterManager(0) works
 MintController.sol,setMinterManager,newMinterManager == minterManager,arg009,arg009 setMinterManager(oldMinterManager) works


### PR DESCRIPTION
configureController(controller, 0) will now throw.  This will avoid confusion between configuring a controller and removing a controller.  Updated a unit test description.  (The unit test has not been written yet).