### PR TITLE
[CENT-367] Rewrite unit tests to use MasterMinter

### DIFF
--- a/contracts/minting/MasterMinter.sol
+++ b/contracts/minting/MasterMinter.sol
@@ -25,4 +25,7 @@ import './MintController.sol';
 
 contract MasterMinter is MintController {
 
+    constructor(address _minterManager) MintController(_minterManager) public {
+
+    }
 }

--- a/test/minting/MintControllerUtils.js
+++ b/test/minting/MintControllerUtils.js
@@ -19,8 +19,6 @@ function MintControllerState(owner, controllers, minterManager) {
     this.controllers = controllers;
     this.minterManager = minterManager;
     this.checkState = async function(mintController) {await checkMintControllerState(mintController, this)};
-//    this.clone = function(){return clone(this);};
-//    this.clone = function(){return new MintControllerState(this.owner, clone(this.controllers), this.minterManager)};
 }
 
 // Default state of MintController when it is deployed
@@ -42,9 +40,9 @@ async function getActualMintControllerState(mintController, accounts) {
 
 // Deploys a FiatTokenV1 with a MintController contract as the masterMinter.
 // Uses the same workflow we would do in production - first deploy FiatToken then set the masterMinter.
-async function initializeTokenWithProxyAndMintController(rawToken) {
+async function initializeTokenWithProxyAndMintController(rawToken, MintControllerArtifact) {
    var tokenConfig = await initializeTokenWithProxy(rawToken);
-   var mintController = await MintController.new(tokenConfig.token.address, {from:Accounts.mintOwnerAccount});
+   var mintController = await MintControllerArtifact.new(tokenConfig.token.address, {from:Accounts.mintOwnerAccount});
    await tokenConfig.token.updateMasterMinter(mintController.address, {from:Accounts.tokenOwnerAccount});
     var tokenConfigWithMinter = {
         proxy: tokenConfig.proxy,

--- a/test/minting/MintP0BasicTests.js
+++ b/test/minting/MintP0BasicTests.js
@@ -1,4 +1,5 @@
 var MintController = artifacts.require('minting/MintController');
+var MasterMinter = artifacts.require('minting/MasterMinter');
 var FiatToken = artifacts.require('FiatTokenV1');
 
 var BigNumber = require('bignumber.js');
@@ -21,11 +22,19 @@ var checkMintControllerState = mintUtils.checkMintControllerState;
 
 var zeroAddress = "0x0000000000000000000000000000000000000000";
 
-async function run_tests(newToken, accounts) {
+async function run_tests_MintController(newToken, accounts) {
+    run_MINT_tests(newToken, MintController, accounts);
+}
+
+async function run_tests_MasterMinter(newToken, accounts) {
+    run_MINT_tests(newToken, MasterMinter, accounts);
+}
+
+async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
 
     beforeEach('Make fresh token contract', async function () {
         rawToken = await newToken();
-        tokenConfig = await initializeTokenWithProxyAndMintController(rawToken);
+        tokenConfig = await initializeTokenWithProxyAndMintController(rawToken, MintControllerArtifact);
         token = tokenConfig.token;
         mintController = tokenConfig.mintController;
         expectedMintControllerState = clone(tokenConfig.customState);
@@ -626,8 +635,5 @@ async function run_tests(newToken, accounts) {
 }
 
 var testWrapper = require('./../TestWrapper');
-testWrapper.execute('MINTp0_BasicTests', run_tests);
-
-module.exports = {
-  run_tests: run_tests,
-}
+testWrapper.execute('MINTp0_BasicTests MintController', run_tests_MintController);
+testWrapper.execute('MINTp0_BasicTests MasterMinter', run_tests_MasterMinter);

--- a/test/minting/MintP0_ABITests.js
+++ b/test/minting/MintP0_ABITests.js
@@ -1,4 +1,5 @@
 var MintController = artifacts.require('minting/MintController');
+var MasterMinter = artifacts.require('minting/MasterMinter');
 var FiatToken = artifacts.require('FiatTokenV1');
 
 var BigNumber = require('bignumber.js');
@@ -28,11 +29,19 @@ var sendRawTransaction = abiUtils.sendRawTransaction;
 var msgData = abiUtils.msgData;
 var msgData1 = abiUtils.msgData1;
 
-async function run_tests(newToken, accounts) {
+async function run_tests_MintController(newToken, accounts) {
+    run_MINT_tests(newToken, MintController, accounts);
+}
+
+async function run_tests_MasterMinter(newToken, accounts) {
+    run_MINT_tests(newToken, MasterMinter, accounts);
+}
+
+async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
 
     beforeEach('Make fresh token contract', async function () {
         rawToken = await newToken();
-        tokenConfig = await initializeTokenWithProxyAndMintController(rawToken);
+        tokenConfig = await initializeTokenWithProxyAndMintController(rawToken, MintControllerArtifact);
         token = tokenConfig.token;
         mintController = tokenConfig.mintController;
         expectedMintControllerState = clone(tokenConfig.customState);
@@ -63,8 +72,6 @@ async function run_tests(newToken, accounts) {
 }
 
 var testWrapper = require('./../TestWrapper');
-testWrapper.execute('MINTp0_ABITests', run_tests);
+testWrapper.execute('MINTp0_ABITests MintController', run_tests_MintController);
+testWrapper.execute('MINTp0_ABITests MasterMinter', run_tests_MasterMinter);
 
-module.exports = {
-  run_tests: run_tests,
-}


### PR DESCRIPTION
- Fixed bug in MasterMinter.sol (missing constructor).
- Modified MINT p0 unit tests to run using a MintController and a MasterMinter.  This will be necessary because future contracts may inherit from MintController, so we want to verify that both MintController and MasterMinter exhibit the desired behavior.