### PR TITLE
Solidity style fixes to multi-issuer contracts

### DIFF
--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -5,8 +5,8 @@
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is furnished to
-* do so, subject to the following conditions:
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
 *
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
@@ -14,9 +14,10 @@
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
 */
 
 pragma solidity ^0.4.24;
@@ -33,11 +34,14 @@ contract Controller is Ownable {
     // The controller manages a single worker address.
     mapping(address => address) public controllers;
 
-    event ControllerConfigured(address indexed _controller, address indexed _worker);
+    event ControllerConfigured(
+        address indexed _controller,
+        address indexed _worker
+    );
     event ControllerRemoved(address indexed _controller);
 
     /**
-     * @dev ensure that the caller is the controller of a non-zero worker address
+     * @dev ensure that caller is the controller of a non-zero worker address
      */
     modifier onlyController() {
         require(controllers[msg.sender] != address(0));
@@ -51,9 +55,16 @@ contract Controller is Ownable {
 
     /**
      * @dev set the controller of a particular _worker
-     * Argument _worker must not be 0x00, call removeController(_controller) instead.
+     *
+     * Argument _worker must not be 0x00. Call removeController(_controller)
+     * instead to disable the controller.
      */
-    function configureController(address _controller, address _worker) onlyOwner public returns (bool) {
+    function configureController(
+        address _controller,
+        address _worker
+    )
+        onlyOwner public returns (bool)
+    {
         require(_worker != address(0));
         controllers[_controller] = _worker;
         emit ControllerConfigured(_controller, _worker);
@@ -63,7 +74,11 @@ contract Controller is Ownable {
     /**
      * @dev disables a controller by setting its worker to address(0);
      */
-    function removeController(address _controller) onlyOwner public returns (bool) {
+    function removeController(
+        address _controller
+    )
+        onlyOwner public returns (bool)
+    {
         controllers[_controller] = address(0);
         emit ControllerRemoved(_controller);
         return true;

--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -54,8 +54,7 @@ contract Controller is Ownable {
     // onlyOwner functions
 
     /**
-     * @dev set the controller of a particular _worker
-     *
+     * @dev set the controller of a particular _worker.
      * Argument _worker must not be 0x00. Call removeController(_controller)
      * instead to disable the controller.
      */

--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -22,7 +22,7 @@
 
 pragma solidity ^0.4.24;
 
-import './../Ownable.sol';
+import "./../Ownable.sol";
 
 /**
  * @title Controller

--- a/contracts/minting/MasterMinter.sol
+++ b/contracts/minting/MasterMinter.sol
@@ -22,11 +22,10 @@
 
 pragma solidity ^0.4.24;
 
-import './MintController.sol';
+import "./MintController.sol";
 
 contract MasterMinter is MintController {
 
     constructor(address _minterManager) MintController(_minterManager) public {
-
     }
 }

--- a/contracts/minting/MasterMinter.sol
+++ b/contracts/minting/MasterMinter.sol
@@ -5,8 +5,8 @@
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is furnished to
-* do so, subject to the following conditions:
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
 *
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
@@ -14,9 +14,10 @@
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
 */
 
 pragma solidity ^0.4.24;

--- a/contracts/minting/MintController.sol
+++ b/contracts/minting/MintController.sol
@@ -69,7 +69,7 @@ contract MintController is Controller {
     );
 
     constructor(address _minterManager) public {
-        minterManager =  MinterManagementInterface(_minterManager);
+        minterManager = MinterManagementInterface(_minterManager);
     }
 
     // onlyOwner functions

--- a/contracts/minting/MintController.sol
+++ b/contracts/minting/MintController.sol
@@ -22,8 +22,8 @@
 
 pragma solidity ^0.4.24;
 
-import './Controller.sol';
-import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
+import "./Controller.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 // Using an interface for managing minters so that MintController
 // can be used for managing minters with different contracts.

--- a/contracts/minting/MintController.sol
+++ b/contracts/minting/MintController.sol
@@ -5,8 +5,8 @@
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-* copies of the Software, and to permit persons to whom the Software is furnished to
-* do so, subject to the following conditions:
+* copies of the Software, and to permit persons to whom the Software is
+* furnished to do so, subject to the following conditions:
 *
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
@@ -14,9 +14,10 @@
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-* WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+* OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+* THE SOFTWARE.
 */
 
 pragma solidity ^0.4.24;
@@ -29,7 +30,11 @@ import 'openzeppelin-solidity/contracts/math/SafeMath.sol';
 interface MinterManagementInterface {
     function isMinter(address account) external view returns (bool);
     function minterAllowance(address minter) external view returns (uint256);
-    function configureMinter(address minter, uint256 minterAllowedAmount) external returns (bool);
+    function configureMinter(
+        address minter,
+        uint256 minterAllowedAmount
+    )
+    external returns (bool);
     function removeMinter(address minter) external returns (bool);
 }
 
@@ -43,10 +48,25 @@ contract MintController is Controller {
 
     MinterManagementInterface public minterManager;
 
-    event MinterManagerSet(address indexed oldMinterManager, address indexed newMinterManager);
-    event MinterConfigured(address indexed msgSender, address indexed minter, uint256 allowance);
-    event MinterRemoved(address indexed msgSender, address indexed minter);
-    event MinterAllowanceIncrement(address indexed msgSender, address indexed minter, uint256 increment, uint256 newAllowance);
+    event MinterManagerSet(
+        address indexed oldMinterManager,
+        address indexed newMinterManager
+    );
+    event MinterConfigured(
+        address indexed msgSender,
+        address indexed minter,
+        uint256 allowance
+    );
+    event MinterRemoved(
+        address indexed msgSender,
+        address indexed minter
+    );
+    event MinterAllowanceIncrement(
+        address indexed msgSender,
+        address indexed minter,
+        uint256 increment,
+        uint256 newAllowance
+    );
 
     constructor(address _minterManager) public {
         minterManager =  MinterManagementInterface(_minterManager);
@@ -57,7 +77,11 @@ contract MintController is Controller {
     /**
      * @dev sets the minterManager
      */
-    function setMinterManager(address _newMinterManager) onlyOwner public returns (bool) {
+    function setMinterManager(
+        address _newMinterManager
+    )
+        onlyOwner public returns (bool)
+    {
         emit MinterManagerSet(minterManager, _newMinterManager);
         minterManager = MinterManagementInterface(_newMinterManager);
         return true;
@@ -77,35 +101,54 @@ contract MintController is Controller {
     /**
      * @dev Enables the minter and sets its allowance
      */
-    function configureMinter(uint256 newAllowance) onlyController public returns (bool) {
+    function configureMinter(
+        uint256 newAllowance
+    )
+        onlyController public returns (bool)
+    {
         address minter = controllers[msg.sender];
         emit MinterConfigured(msg.sender, minter, newAllowance);
         return internal_setMinterAllowance(minter, newAllowance);
     }
 
-     /**
+    /**
      * @dev Increases the minter allowance if and only if the minter is
-     * currently active. The controller can safely send a signed incrementMinterAllowance()
-     * transaction to a minter and not worry about it being used to undo a removeMinter()
-     * transaction.
+     * currently active. The controller can safely send a signed
+     * incrementMinterAllowance() transaction to a minter and not worry
+     * about it being used to undo a removeMinter() transaction.
      */
-     function incrementMinterAllowance(uint256 allowanceIncrement) onlyController public returns (bool) {
+    function incrementMinterAllowance(
+        uint256 allowanceIncrement
+    )
+        onlyController public returns (bool)
+    {
         address minter = controllers[msg.sender];
         require(minterManager.isMinter(minter));
 
         uint256 currentAllowance = minterManager.minterAllowance(minter);
         uint256 newAllowance = currentAllowance.add(allowanceIncrement);
 
-        emit MinterAllowanceIncrement(msg.sender, minter, allowanceIncrement, newAllowance);
+        emit MinterAllowanceIncrement(
+            msg.sender,
+            minter,
+            allowanceIncrement,
+            newAllowance
+        );
         return internal_setMinterAllowance(minter, newAllowance);
     }
 
    // Internal functions
 
     /**
-     * @dev Uses the MinterManagementInterface to enable the minter and set its allowance.
+     * @dev Uses the MinterManagementInterface to enable the minter and
+     * set its allowance.
      */
-   function internal_setMinterAllowance(address minter, uint256 newAllowance) internal returns (bool) {
+    function internal_setMinterAllowance(
+        address minter,
+        uint256 newAllowance
+    )
+        internal returns (bool)
+    {
         return minterManager.configureMinter(minter, newAllowance);
     }
 }


### PR DESCRIPTION
Wraps lines at 80 columns per Solidity style guide. Also uses double quotes in import statements.