### PR TITLE
Fixes expectRevert not checking revert string

### DIFF
--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -40,7 +40,7 @@ contract Controller is Ownable {
      * @dev ensure that the caller is the controller of a non-zero worker address
      */
     modifier onlyController() {
-        require(controllers[msg.sender] != address(0), "The value of controller[msg.sender] must be non-zero.");
+        require(controllers[msg.sender] != address(0), "The value of controllers[msg.sender] must be non-zero.");
         _;
     }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ethereumjs-abi": "^0.6.5",
     "ethereumjs-tx": "1.3.1",
     "g": "^2.0.1",
-    "ganache-cli": "6.1.0",
+    "ganache-cli": "6.2.5",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "npm": "^6.4.1",

--- a/scripts/start-ganache.sh
+++ b/scripts/start-ganache.sh
@@ -1,1 +1,1 @@
-./node_modules/ganache-cli/build/cli.node.js --defaultBalanceEther 1000000 --deterministic --a 15 > ganache-blockchain-log.txt &
+./node_modules/ganache-cli/cli.js --defaultBalanceEther 1000000 --deterministic --a 15 > ganache-blockchain-log.txt &

--- a/test/TokenTestUtils.js
+++ b/test/TokenTestUtils.js
@@ -10,7 +10,7 @@ var BigNumber = require('bignumber.js');
 var trueInStorageFormat = "0x01";
 var decimals = newBigNumber(10);
 var bigZero = newBigNumber(0);
-var zeroAddress = '0x' + bigZero.toString(16, 40);
+var zeroAddress = '0x0000000000000000000000000000000000000000';
 var bigHundred = newBigNumber(100);
 var maxAmount = "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 var assertDiff = require('assert-diff');
@@ -623,6 +623,7 @@ module.exports = {
     currency: currency,
     decimals: decimals,
     bigZero: bigZero,
+    zeroAddress: zeroAddress,
     bigHundred: bigHundred,
     debugLogging: debugLogging,
     solidityErrors: solidityErrors,

--- a/test/TokenTestUtils.js
+++ b/test/TokenTestUtils.js
@@ -588,10 +588,10 @@ async function getInitializedV1(token) {
     var initialized;
     var masterMinterStart;
     var masterMinterAddress;
-    if (slot8DataLength == 4) {
+    if (slot8DataLength == 3) {
         //Validate proxy not yet initialized
         for (var i = 0; i <= 20; i++) {
-            assert.equal("0x00", await web3.eth.getStorageAt(token.address, i));
+            assert.equal("0x0", await web3.eth.getStorageAt(token.address, i));
         }
         initialized = slot8Data;
     } else {

--- a/test/TokenTestUtils.js
+++ b/test/TokenTestUtils.js
@@ -38,6 +38,11 @@ var implSlot = "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8
 // set to true to enable verbose logging in the tests
 var debugLogging = false;
 
+// Common solidity error messages 
+var solidityErrors = {
+    "argumentType": "argument must be a string, Buffer, ArrayBuffer, Array, or array-like object."
+}
+
 // Returns a new BN object
 function newBigNumber(value) {
     var hex = new BigNumber(value).toString(16);
@@ -544,11 +549,11 @@ async function upgradeTo(proxy, upgradedToken, proxyUpgraderAccount) {
 }
 
 async function expectRevert(contractPromise) {
-    await expectError(contractPromise, 'error:');
+    await expectError(contractPromise, "revert");
 }
 
 async function expectJump(contractPromise) {
-    await expectError(contractPromise, 'invalid opcode');
+    await expectError(contractPromise, "invalid opcode");
 }
 
 async function expectError(contractPromise, errorMsg) {
@@ -556,9 +561,8 @@ async function expectError(contractPromise, errorMsg) {
         await contractPromise;
         assert.fail('Expected error ${errorMsg}, but no error received');
     } catch (error) {
-//      Todo: perform error message check in separate PR
-//        var correctErrorMsgReceived = error.message.includes(errorMsg);
-//        assert(correctErrorMsgReceived, `Expected ${errorMsg}, got ${error.message} instead`);
+        var correctErrorMsgReceived = error.message.includes(errorMsg);
+        assert(correctErrorMsgReceived, `Expected ${errorMsg}, got ${error.message} instead`);
     }
 }
 
@@ -621,6 +625,7 @@ module.exports = {
     bigZero: bigZero,
     bigHundred: bigHundred,
     debugLogging: debugLogging,
+    solidityErrors: solidityErrors,
     calculateFeeAmount: calculateFeeAmount,
     checkTransferEventsWithFee: checkTransferEventsWithFee,
     checkTransferEvents: checkTransferEvents,

--- a/test/assert/ABITests.test.js
+++ b/test/assert/ABITests.test.js
@@ -81,7 +81,6 @@ async function run_tests(newToken, accounts) {
              AccountPrivateKeys.pauserPrivateKey,
              token.address);
         await expectRevert(sendRawTransaction(raw));
-        await expectRevert(sendRawTransaction(raw));
     });
 
     it('abi005 Pausable constructor is not a function', async function () {
@@ -206,7 +205,7 @@ async function run_tests(newToken, accounts) {
 
     it('abi028 UpgradeabilityProxy._upgradeTo is internal', async function () {
         let badData = mockStringAddressEncode('_upgradeTo(string,address)', Accounts.pauserAccount);
-        let raw = makeRawTransaction(
+        let raw = await makeRawTransaction(
             badData,
             Accounts.tokenOwnerAccount,
             AccountPrivateKeys.tokenOwnerPrivateKey,

--- a/test/assert/FiatTokenLegacy.test.js
+++ b/test/assert/FiatTokenLegacy.test.js
@@ -5,6 +5,7 @@ var currency = tokenUtils.currency;
 var decimals = tokenUtils.decimals
 var bigZero = tokenUtils.bigZero;
 var bigHundred = tokenUtils.bigHundred;
+var zeroAddress = tokenUtils.zeroAddress;
 var mint = tokenUtils.mint;
 var burn = tokenUtils.burn;
 var setMinter = tokenUtils.setMinter;
@@ -204,7 +205,7 @@ async function run_tests(newToken, accounts) {
     let allowed = await token.allowance.call(accounts[0], accounts[3]);
     assert.isTrue(allowed.cmp(newBigNumber(100))==0);
 
-    await expectRevert(token.transferFrom(accounts[0], 0, 50, { from: accounts[3] }));
+    await expectRevert(token.transferFrom(accounts[0], zeroAddress, 50, { from: accounts[3] }));
 
     let balance0 = await token.balanceOf(accounts[0]);
     assert.equal(balance0, 500);

--- a/test/basic/NegativeTests.js
+++ b/test/basic/NegativeTests.js
@@ -23,8 +23,7 @@ var AccountUtils = require('./../AccountUtils.js');
 var Accounts = AccountUtils.Accounts;
 
 var amount = 100;
-let longZero = 0x0000000000000000000000000000000000000000;
-let shortZero = 0x00;
+var zeroAddress = tokenUtils.zeroAddress;
 
 async function run_tests(newToken, accounts) {
 
@@ -97,9 +96,7 @@ async function run_tests(newToken, accounts) {
       {'variable': 'isAccountMinter.minterAccount', 'expectedValue': true},
       {'variable': 'minterAllowance.minterAccount', 'expectedValue': newBigNumber(amount)}
     ]
-    await expectRevert(token.mint("0x0", amount, {from: Accounts.minterAccount}));
-    await expectRevert(token.mint("0x0000000000000000000000000000000000000000", amount, {from: Accounts.minterAccount}));
-    await expectRevert(token.mint(0x0000000000000000000000000000000000000000, amount, {from: Accounts.minterAccount}));
+    await expectRevert(token.mint(zeroAddress, amount, {from: Accounts.minterAccount}));
     await checkVariables([token], [customVars]);
   });
 
@@ -151,7 +148,7 @@ async function run_tests(newToken, accounts) {
       {'variable': 'totalSupply', 'expectedValue': newBigNumber(50)},
       {'variable': 'allowance.arbitraryAccount.arbitraryAccount2', 'expectedValue': newBigNumber(50)}
     ]
-    await expectRevert(token.transferFrom(Accounts.arbitraryAccount, "0x0", 50, {from: Accounts.arbitraryAccount2}));
+    await expectRevert(token.transferFrom(Accounts.arbitraryAccount, zeroAddress, 50, {from: Accounts.arbitraryAccount2}));
     await checkVariables([token], [customVars]);
   });
 
@@ -306,7 +303,7 @@ async function run_tests(newToken, accounts) {
       {'variable': 'balances.arbitraryAccount', 'expectedValue': newBigNumber(50)},
       {'variable': 'totalSupply', 'expectedValue': newBigNumber(50)}
     ]
-    await expectRevert(token.transfer("0x0", 50, {from: Accounts.arbitraryAccount}));
+    await expectRevert(token.transfer(zeroAddress, 50, {from: Accounts.arbitraryAccount}));
     await checkVariables([token], [customVars]);
   });
 
@@ -627,47 +624,39 @@ async function run_tests(newToken, accounts) {
   });
 
   it('nt064 transferOwnership should fail on 0x0', async function () {
-    await expectRevert(token.transferOwnership(longZero, { from: Accounts.tokenOwnerAccount }));
-    await expectRevert(token.transferOwnership(shortZero, { from: Accounts.tokenOwnerAccount }));
+    await expectRevert(token.transferOwnership(zeroAddress, { from: Accounts.tokenOwnerAccount }));
   });
 
   it('nt057 updateMasterMinter should fail on 0x0', async function () {
-    await expectRevert(token.updateMasterMinter(longZero, { from: Accounts.tokenOwnerAccount }));
-    await expectRevert(token.updateMasterMinter(shortZero, { from: Accounts.tokenOwnerAccount }));
+    await expectRevert(token.updateMasterMinter(zeroAddress, { from: Accounts.tokenOwnerAccount }));
   });
 
   it('nt058 updatePauser should fail on 0x0', async function () {
-    await expectRevert(token.updatePauser(longZero, { from: Accounts.tokenOwnerAccount }));
-    await expectRevert(token.updatePauser(shortZero, { from: Accounts.tokenOwnerAccount }));
+    await expectRevert(token.updatePauser(zeroAddress, { from: Accounts.tokenOwnerAccount }));
   });
 
   it('nt059 updateBlacklister should fail on 0x0', async function () {
-    await expectRevert(token.updateBlacklister(longZero, { from: Accounts.tokenOwnerAccount }));
-    await expectRevert(token.updateBlacklister(shortZero, { from: Accounts.tokenOwnerAccount }));
+    await expectRevert(token.updateBlacklister(zeroAddress, { from: Accounts.tokenOwnerAccount }));
   });
 
   it('nt060 initialize should fail when _masterMinter is 0x0', async function () {
     rawToken = await newToken();
-    await expectRevert(customInitializeTokenWithProxy(rawToken, longZero, Accounts.pauserAccount, Accounts.blacklisterAccount, Accounts.tokenOwnerAccount));
-    await expectRevert(customInitializeTokenWithProxy(rawToken, shortZero, Accounts.pauserAccount, Accounts.blacklisterAccount, Accounts.tokenOwnerAccount));
+    await expectRevert(customInitializeTokenWithProxy(rawToken, zeroAddress, Accounts.pauserAccount, Accounts.blacklisterAccount, Accounts.tokenOwnerAccount));
   });
 
   it('nt061 initialize should fail when _pauser is 0x0', async function () {
     rawToken = await newToken();
-    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, longZero, Accounts.blacklisterAccount, Accounts.tokenOwnerAccount));
-    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, shortZero, Accounts.blacklisterAccount, Accounts.tokenOwnerAccount));
+    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, zeroAddress, Accounts.blacklisterAccount, Accounts.tokenOwnerAccount));
   });
 
   it('nt062 initialize should fail when _blacklister is 0x0', async function () {
     rawToken = await newToken();
-    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, Accounts.pauserAccount, longZero, Accounts.tokenOwnerAccount));
-    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, Accounts.pauserAccount, shortZero, Accounts.tokenOwnerAccount));
+    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, Accounts.pauserAccount, zeroAddress, Accounts.tokenOwnerAccount));
   });
 
   it('nt063 initialize should fail when _owner is 0x0', async function () {
     rawToken = await newToken();
-    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, Accounts.pauserAccount, Accounts.blacklisterAccount, longZero));
-    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, Accounts.pauserAccount, Accounts.blacklisterAccount, shortZero));
+    await expectRevert(customInitializeTokenWithProxy(rawToken, Accounts.masterMinterAccount, Accounts.pauserAccount, Accounts.blacklisterAccount, zeroAddress));
   });
 }
 

--- a/test/minting2/MintControllerTests.js
+++ b/test/minting2/MintControllerTests.js
@@ -96,11 +96,11 @@ async function run_tests(newToken, accounts) {
    });
 
    it('only controller removes a minter', async function () {
-        await expectError(mintController.removeMinter({from: Accounts.controller1Account}), "Sender must be a controller");
+        await expectError(mintController.removeMinter({from: Accounts.controller1Account}), "The value of controllers[msg.sender] must be non-zero.");
    });
 
    it('only controller configures a minter', async function () {
-        await expectError(mintController.configureMinter(0, {from: Accounts.controller1Account}), "Sender must be a controller");
+        await expectError(mintController.configureMinter(0, {from: Accounts.controller1Account}), "The value of controllers[msg.sender] must be non-zero.");
    });
 
    it('increment minter allowance', async function () {
@@ -126,7 +126,7 @@ async function run_tests(newToken, accounts) {
    });
 
    it('only controller increments allowance', async function () {
-        await expectError(mintController.incrementMinterAllowance(0, {from: Accounts.controller1Account}), "Sender must be a controller");
+        await expectError(mintController.incrementMinterAllowance(0, {from: Accounts.controller1Account}), "The value of controllers[msg.sender] must be non-zero.");
    });
 
    it('only active minters can have allowance incremented', async function () {
@@ -137,7 +137,7 @@ async function run_tests(newToken, accounts) {
         await checkMINTp0([token, mintController], [expectedTokenState, expectedMintControllerState]);
 
         // increment minter allowance
-        await expectError(mintController.incrementMinterAllowance(amount, {from: Accounts.controller1Account}), "Can only increment allowance for enabled minter");
+        await expectError(mintController.incrementMinterAllowance(amount, {from: Accounts.controller1Account}), "Can only increment allowance for minters in minterManager.");
    });
 }
 

--- a/test/minting2/MintP0_ABITests.js
+++ b/test/minting2/MintP0_ABITests.js
@@ -4,8 +4,7 @@ var FiatToken = artifacts.require('FiatTokenV1');
 
 var tokenUtils = require('./../TokenTestUtils.js');
 var checkMINTp0 = tokenUtils.checkMINTp0;
-var expectRevert = tokenUtils.expectRevert;
-var expectJump = tokenUtils.expectJump;
+var expectError = tokenUtils.expectError;
 var bigZero = tokenUtils.bigZero;
 var maxAmount = tokenUtils.maxAmount;
 var solidityErrors = tokenUtils.solidityErrors;

--- a/test/minting2/MintP0_ABITests.js
+++ b/test/minting2/MintP0_ABITests.js
@@ -8,6 +8,7 @@ var expectRevert = tokenUtils.expectRevert;
 var expectJump = tokenUtils.expectJump;
 var bigZero = tokenUtils.bigZero;
 var maxAmount = tokenUtils.maxAmount;
+var solidityErrors = tokenUtils.solidityErrors;
 
 var clone = require('clone');
 
@@ -19,8 +20,6 @@ var getAccountState = AccountUtils.getAccountState;
 var MintControllerState = AccountUtils.MintControllerState;
 var initializeTokenWithProxyAndMintController = mintUtils.initializeTokenWithProxyAndMintController;
 var checkMintControllerState = mintUtils.checkMintControllerState;
-
-var zeroAddress = "0x0000000000000000000000000000000000000000";
 
 var abiUtils = require('./../ABIUtils.js');
 var makeRawTransaction = abiUtils.makeRawTransaction;
@@ -55,7 +54,7 @@ async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
              Accounts.mintOwnerAccount,
              AccountPrivateKeys.mintOwnerPrivateKey,
              mintController.address);
-         await expectRevert(sendRawTransaction(raw));
+        await expectError(sendRawTransaction(raw), solidityErrors.argumentType);
     });
 
     it('abi101 setOwner is internal', async function () {
@@ -65,7 +64,7 @@ async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
             Accounts.mintOwnerAccount,
             AccountPrivateKeys.mintOwnerPrivateKey,
             mintController.address);
-        await expectRevert(sendRawTransaction(raw));
+        await expectError(sendRawTransaction(raw), solidityErrors.argumentType);
     });
 
 }

--- a/test/minting3/MintP0_BasicTests.js
+++ b/test/minting3/MintP0_BasicTests.js
@@ -105,7 +105,7 @@ async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
     });
 
     it('bt010 removeMinter reverts when msg.sender is not a controller', async function () {
-        await expectError(mintController.removeMinter({from: Accounts.controller1Account}), "Sender must be a controller");
+        await expectError(mintController.removeMinter({from: Accounts.controller1Account}), "The value of controllers[msg.sender] must be non-zero.");
     });
 
     it('bt011 removeMinter sets minters[M] to 0', async function () {
@@ -129,7 +129,7 @@ async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
     });
 
     it('bt012 configureMinter reverts when msg.sender is not a controller', async function () {
-        await expectError(mintController.configureMinter(50, {from: Accounts.controller1Account}), "Sender must be a controller");
+        await expectError(mintController.configureMinter(50, {from: Accounts.controller1Account}), "The value of controllers[msg.sender] must be non-zero.");
     });
 
     it('bt013 configureMinter works when controllers[msg.sender]=M', async function () {
@@ -148,7 +148,7 @@ async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
     });
 
     it('bt014 incrementMinterAllowance reverts if msg.sender is not a controller', async function () {
-        await expectError(mintController.incrementMinterAllowance(50, {from: Accounts.controller1Account}), "Sender must be a controller");
+        await expectError(mintController.incrementMinterAllowance(50, {from: Accounts.controller1Account}), "The value of controllers[msg.sender] must be non-zero.");
     });
 
     it('bt015 incrementMinterAllowance works when controllers[msg.sender]=M', async function () {
@@ -443,7 +443,7 @@ async function run_MINT_tests(newToken, MintControllerArtifact, accounts) {
         var isMinter = await minterManager.isMinter(Accounts.minterAccount);
         assert.isFalse(isMinter);
 
-        await expectError(mintController.incrementMinterAllowance(amount, {from: Accounts.controller1Account}), "Can only increment allowance for enabled minter");
+        await expectError(mintController.incrementMinterAllowance(amount, {from: Accounts.controller1Account}), "Can only increment allowance for minters in minterManager.");
         expectedMintControllerState.controllers['controller1Account'] = Accounts.minterAccount;
         await checkMINTp0([token, mintController], [expectedTokenState, expectedMintControllerState]);
     });

--- a/test/misc/MiscTests.js
+++ b/test/misc/MiscTests.js
@@ -445,7 +445,7 @@ async function run_tests(newToken, accounts) {
     var newProxy = await FiatTokenProxy.new(rawToken.address, { from: Accounts.arbitraryAccount });
     var token = await FiatToken.at(newProxy.address);
     var initialized = await getInitializedV1(token);
-    assert.equal("0x00", initialized);
+    assert.equal("0x0", initialized);
   });
 
   it('ms047 configureMinter works on amount=2^256-1', async function() {

--- a/test/proxy/ProxyNegativeTests.js
+++ b/test/proxy/ProxyNegativeTests.js
@@ -5,6 +5,7 @@ assertDiff.options.strict = true;
 
 var bigZero = tokenUtils.bigZero;
 var bigHundred = tokenUtils.bigHundred;
+var zeroAddress = tokenUtils.zeroAddress;
 var mint = tokenUtils.mint;
 var expectRevert = tokenUtils.expectRevert;
 var checkVariables = tokenUtils.checkVariables;
@@ -46,7 +47,7 @@ async function run_tests(newToken, accounts) {
 
   it('nut003 should fail to upgradeTo to null contract address', async function () {
     var upgradedToken = await UpgradedFiatToken.new();
-    await expectRevert(proxy.upgradeTo("0x0", token, {from: Accounts.proxyOwnerAccount}));
+    await expectRevert(proxy.upgradeTo(zeroAddress, {from: Accounts.proxyOwnerAccount}));
 
     customVars = [];
     await checkVariables([token], [customVars]);
@@ -55,7 +56,7 @@ async function run_tests(newToken, accounts) {
   it('nut004 should fail to upgradeToAndCall to null contract address', async function () {
     var upgradedToken = await UpgradedFiatToken.new();
     const initializeData = encodeCall('pauser', [], []);
-    await expectRevert(proxy.upgradeToAndCall("0x0", initializeData, { from: Accounts.proxyOwnerAccount }));
+    await expectRevert(proxy.upgradeToAndCall(zeroAddress, initializeData, { from: Accounts.proxyOwnerAccount }));
 
     customVars = [];
     await checkVariables([token], [customVars]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1108,7 +1108,7 @@ bn.js@4.11.6:
   version "4.11.6"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
 
-bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.3, bn.js@^4.11.8, bn.js@^4.4.0, bn.js@^4.8.0:
+bn.js@4.11.8, bn.js@^4.10.0, bn.js@^4.11.0, bn.js@^4.11.3, bn.js@^4.11.8, bn.js@^4.4.0, bn.js@^4.8.0:
   version "4.11.8"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
 
@@ -2976,12 +2976,14 @@ g@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/g/-/g-2.0.1.tgz#0b5963ebd0ca70e3bc8c6766934a021821c8b857"
 
-ganache-cli@6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.1.0.tgz#486c846497204b644166b5f0f74c9b41d02bdc25"
+ganache-cli@6.2.5:
+  version "6.2.5"
+  resolved "https://registry.yarnpkg.com/ganache-cli/-/ganache-cli-6.2.5.tgz#efda5115fa3a0c62d7f5729fdd78da70ca55b1ad"
+  integrity sha512-E4SP8QNeuc2N/ojFoCK+08OYHX8yrtGeFtipZmJPPTQ6U8Hmq3JcbXZDxQfChPQUY5mtbRSwptJa4EtiQyJjAQ==
   dependencies:
-    source-map-support "^0.5.3"
-    webpack-cli "^2.0.9"
+    bn.js "4.11.8"
+    source-map-support "0.5.9"
+    yargs "11.1.0"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -6866,6 +6868,14 @@ source-map-resolve@^0.5.0:
     source-map-url "^0.4.0"
     urix "^0.1.0"
 
+source-map-support@0.5.9:
+  version "0.5.9"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.9.tgz#41bc953b2534267ea2d605bccfa7bfa3111ced5f"
+  integrity sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==
+  dependencies:
+    buffer-from "^1.0.0"
+    source-map "^0.6.0"
+
 source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
@@ -7869,6 +7879,24 @@ yargs-parser@^9.0.2:
   dependencies:
     camelcase "^4.1.0"
 
+yargs@11.1.0, yargs@^11.0.0, yargs@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
+  integrity sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
+
 yargs@6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-6.4.0.tgz#816e1a866d5598ccf34e5596ddce22d92da490d4"
@@ -7905,23 +7933,6 @@ yargs@6.6.0:
     which-module "^1.0.0"
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
-
-yargs@^11.0.0, yargs@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.1.0.tgz#90b869934ed6e871115ea2ff58b03f4724ed2d77"
-  dependencies:
-    cliui "^4.0.0"
-    decamelize "^1.1.1"
-    find-up "^2.1.0"
-    get-caller-file "^1.0.1"
-    os-locale "^2.0.0"
-    require-directory "^2.1.1"
-    require-main-filename "^1.0.1"
-    set-blocking "^2.0.0"
-    string-width "^2.0.0"
-    which-module "^2.0.0"
-    y18n "^3.2.1"
-    yargs-parser "^9.0.2"
 
 yargs@^4.6.0, yargs@^4.7.1:
   version "4.8.1"


### PR DESCRIPTION
-Fixes expectRevert not checking expectedErrorMessage == actualErrorMessage
-Fixes revert string in tests inconsistent with revert string in contract
-Adds missing await in test
-Makes revert string use plural noun to match solidity variable
-Fixes 0x0 address throwing errors (replaces will full null address) due to upgrade in web3
-Upgrades ganache-cli used
