### PR TITLE
explicit conversion of minterManager to address type

### DIFF
--- a/contracts/minting/MintController.sol
+++ b/contracts/minting/MintController.sol
@@ -84,7 +84,7 @@ contract MintController is Controller {
         onlyOwner 
         returns (bool)
     {
-        emit MinterManagerSet(minterManager, _newMinterManager);
+        emit MinterManagerSet(address(minterManager), _newMinterManager);
         minterManager = MinterManagementInterface(_newMinterManager);
         return true;
     }


### PR DESCRIPTION
Solidity docs state that "Starting with version 0.5.0 contracts do not derive from the address type, but can still be explicitly converted to address," so this change would be required if we upgrade, and worth doing regardless. Fixes https://github.com/centrehq/centre-tokens/issues/260.