### PR TITLE
Updates dependency installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Depends on truffle and testrpc for testing.
 install truffle:
 ```npm install -g truffle```
 
-install ganache-cli:
-```npm install -g ganache-cli```
+install yarn:
+```npm install -g yarn```
 
 install project npm dependencies:
-```npm install```
+```yarn install```
 
 # Testing
 All tests are run with:


### PR DESCRIPTION
1. ganache-cli global install is no longer needed as it is now a project dependency
2. yarn is now used (generates lockfile)