### PR TITLE
Add version method

### DIFF
--- a/contracts/v2/FiatTokenV2_1.sol
+++ b/contracts/v2/FiatTokenV2_1.sol
@@ -49,4 +49,12 @@ contract FiatTokenV2_1 is FiatTokenV2 {
 
         _initializedVersion = 2;
     }
+
+    /**
+     * @notice Version string for the EIP712 domain separator
+     * @return Version string
+     */
+    function version() external view returns (string memory) {
+        return "2";
+    }
 }

--- a/test/v2/FiatTokenV2_1.test.ts
+++ b/test/v2/FiatTokenV2_1.test.ts
@@ -74,4 +74,10 @@ contract("FiatTokenV2_1", (accounts) => {
       );
     });
   });
+
+  describe("version", () => {
+    it("returns the version string", async () => {
+      expect(await fiatToken.version()).to.equal("2");
+    });
+  });
 });


### PR DESCRIPTION
Add a getter for the `version` string used to derive the EIP-712 [domain separator](https://github.com/centrehq/centre-tokens/blob/db0feab177e81f7aacd33fa68add0331735837ed/contracts/v2/FiatTokenV2.sol#L49) so that the users of this contract do not have to hard code it in their implementation.

See also: https://github.com/ethereum/EIPs/issues/2613#issuecomment-775490050