### PR TITLE
update multi-issuer minting contracts to v.0.6.12

### DIFF
--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -1,0 +1,103 @@
+/**
+ * Copyright CENTRE SECZ 2021
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pragma solidity 0.6.12;
+
+import { Ownable } from "../v1/Ownable.sol";
+
+/**
+ * @title Controller
+ * @notice Generic implementation of the owner-controller-worker model.
+ * One owner manages many controllers. Each controller manages one worker.
+ * Workers may be reused across different controllers.
+ */
+contract Controller is Ownable {
+    /**
+     * @notice A controller manages a single worker address.
+     * controllers[controller] = worker
+     */
+    mapping(address => address) internal controllers;
+
+    event ControllerConfigured(
+        address indexed _controller,
+        address indexed _worker
+    );
+    event ControllerRemoved(address indexed _controller);
+
+    /**
+     * @notice Ensures that caller is the controller of a non-zero worker
+     * address.
+     */
+    modifier onlyController() {
+        require(
+            controllers[msg.sender] != address(0),
+            "The value of controllers[msg.sender] must be non-zero"
+        );
+        _;
+    }
+
+    /**
+     * @notice Gets the worker at address _controller.
+     */
+    function getWorker(address _controller) external view returns (address) {
+        return controllers[_controller];
+    }
+
+    // onlyOwner functions
+
+    /**
+     * @notice Configure a controller with the given worker.
+     * @param _controller The controller to be configured with a worker.
+     * @param _worker The worker to be set for the newly configured controller.
+     * _worker must not be a non-zero address. To disable a worker,
+     * use removeController instead.
+     */
+    function configureController(address _controller, address _worker)
+        public
+        onlyOwner
+    {
+        require(
+            _controller != address(0),
+            "Controller must be a non-zero address"
+        );
+        require(_worker != address(0), "Worker must be a non-zero address");
+        controllers[_controller] = _worker;
+        emit ControllerConfigured(_controller, _worker);
+    }
+
+    /**
+     * @notice disables a controller by setting its worker to address(0).
+     * @param _controller The controller to disable.
+     */
+    function removeController(address _controller) public onlyOwner {
+        require(
+            _controller != address(0),
+            "Controller must be a non-zero address"
+        );
+        require(
+            controllers[_controller] != address(0),
+            "Worker must be a non-zero address"
+        );
+        controllers[_controller] = address(0);
+        emit ControllerRemoved(_controller);
+    }
+}

--- a/contracts/minting/MasterMinter.sol
+++ b/contracts/minting/MasterMinter.sol
@@ -1,0 +1,35 @@
+/**
+ * Copyright CENTRE SECZ 2021
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pragma solidity 0.6.12;
+
+import "./MintController.sol";
+
+/**
+ * @title MasterMinter
+ * @notice MasterMinter uses multiple controllers to manage minters for a
+ * contract that implements the MinterManagerInterface.
+ * @dev MasterMinter inherits all its functionality from MintController.
+ */
+contract MasterMinter is MintController {
+    constructor(address _minterManager) public MintController(_minterManager) {}
+}

--- a/contracts/minting/MintController.sol
+++ b/contracts/minting/MintController.sol
@@ -1,0 +1,216 @@
+/**
+ * Copyright CENTRE SECZ 2021
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pragma solidity 0.6.12;
+
+import "./Controller.sol";
+import "./MinterManagementInterface.sol";
+import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
+
+/**
+ * @title MintController
+ * @notice The MintController contract manages minters for a contract that
+ * implements the MinterManagerInterface. It lets the owner designate certain
+ * addresses as controllers, and these controllers then manage the
+ * minters by adding and removing minters, as well as modifying their minting
+ * allowance. A controller may manage exactly one minter, but the same minter
+ * address may be managed by multiple controllers.
+ * @dev MintController inherits from the Controller contract. It treats the
+ * Controller workers as minters.
+ */
+contract MintController is Controller {
+    using SafeMath for uint256;
+
+    /**
+     * @title MinterManagementInterface
+     * @notice MintController calls the minterManager to execute/record minter
+     * management tasks, as well as to query the status of a minter address.
+     */
+    MinterManagementInterface internal minterManager;
+
+    event MinterManagerSet(
+        address indexed _oldMinterManager,
+        address indexed _newMinterManager
+    );
+    event MinterConfigured(
+        address indexed _msgSender,
+        address indexed _minter,
+        uint256 _allowance
+    );
+    event MinterRemoved(address indexed _msgSender, address indexed _minter);
+    event MinterAllowanceIncremented(
+        address indexed _msgSender,
+        address indexed _minter,
+        uint256 _increment,
+        uint256 _newAllowance
+    );
+
+    event MinterAllowanceDecremented(
+        address indexed msgSender,
+        address indexed minter,
+        uint256 decrement,
+        uint256 newAllowance
+    );
+
+    /**
+     * @notice Initializes the minterManager.
+     * @param _minterManager The address of the minterManager contract.
+     */
+    constructor(address _minterManager) public {
+        minterManager = MinterManagementInterface(_minterManager);
+    }
+
+    /**
+     * @notice gets the minterManager
+     */
+    function getMinterManager()
+        external
+        view
+        returns (MinterManagementInterface)
+    {
+        return minterManager;
+    }
+
+    // onlyOwner functions
+
+    /**
+     * @notice Sets the minterManager.
+     * @param _newMinterManager The address of the new minterManager contract.
+     */
+    function setMinterManager(address _newMinterManager) public onlyOwner {
+        emit MinterManagerSet(address(minterManager), _newMinterManager);
+        minterManager = MinterManagementInterface(_newMinterManager);
+    }
+
+    // onlyController functions
+
+    /**
+     * @notice Removes the controller's own minter.
+     */
+    function removeMinter() public onlyController returns (bool) {
+        address minter = controllers[msg.sender];
+        emit MinterRemoved(msg.sender, minter);
+        return minterManager.removeMinter(minter);
+    }
+
+    /**
+     * @notice Enables the minter and sets its allowance.
+     * @param _newAllowance New allowance to be set for minter.
+     */
+    function configureMinter(uint256 _newAllowance)
+        public
+        onlyController
+        returns (bool)
+    {
+        address minter = controllers[msg.sender];
+        emit MinterConfigured(msg.sender, minter, _newAllowance);
+        return internal_setMinterAllowance(minter, _newAllowance);
+    }
+
+    /**
+     * @notice Increases the minter's allowance if and only if the minter is an
+     * active minter.
+     * @dev An minter is considered active if minterManager.isMinter(minter)
+     * returns true.
+     */
+    function incrementMinterAllowance(uint256 _allowanceIncrement)
+        public
+        onlyController
+        returns (bool)
+    {
+        require(
+            _allowanceIncrement > 0,
+            "Allowance increment must be greater than 0"
+        );
+        address minter = controllers[msg.sender];
+        require(
+            minterManager.isMinter(minter),
+            "Can only increment allowance for minters in minterManager"
+        );
+
+        uint256 currentAllowance = minterManager.minterAllowance(minter);
+        uint256 newAllowance = currentAllowance.add(_allowanceIncrement);
+
+        emit MinterAllowanceIncremented(
+            msg.sender,
+            minter,
+            _allowanceIncrement,
+            newAllowance
+        );
+
+        return internal_setMinterAllowance(minter, newAllowance);
+    }
+
+    /**
+     * @notice decreases the minter allowance if and only if the minter is
+     * currently active. The controller can safely send a signed
+     * decrementMinterAllowance() transaction to a minter and not worry
+     * about it being used to undo a removeMinter() transaction.
+     */
+    function decrementMinterAllowance(uint256 _allowanceDecrement)
+        public
+        onlyController
+        returns (bool)
+    {
+        require(
+            _allowanceDecrement > 0,
+            "Allowance decrement must be greater than 0"
+        );
+        address minter = controllers[msg.sender];
+        require(
+            minterManager.isMinter(minter),
+            "Can only decrement allowance for minters in minterManager"
+        );
+
+        uint256 currentAllowance = minterManager.minterAllowance(minter);
+        uint256 actualAllowanceDecrement = (
+            currentAllowance > _allowanceDecrement
+                ? _allowanceDecrement
+                : currentAllowance
+        );
+        uint256 newAllowance = currentAllowance.sub(actualAllowanceDecrement);
+
+        emit MinterAllowanceDecremented(
+            msg.sender,
+            minter,
+            actualAllowanceDecrement,
+            newAllowance
+        );
+
+        return internal_setMinterAllowance(minter, newAllowance);
+    }
+
+    // Internal functions
+
+    /**
+     * @notice Uses the MinterManagementInterface to enable the minter and
+     * set its allowance.
+     * @param _minter Minter to set new allowance of.
+     * @param _newAllowance New allowance to be set for minter.
+     */
+    function internal_setMinterAllowance(address _minter, uint256 _newAllowance)
+        internal
+        returns (bool)
+    {
+        return minterManager.configureMinter(_minter, _newAllowance);
+    }
+}

--- a/contracts/minting/MinterManagementInterface.sol
+++ b/contracts/minting/MinterManagementInterface.sol
@@ -1,0 +1,40 @@
+/**
+ * Copyright CENTRE SECZ 2021
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+pragma solidity 0.6.12;
+
+/**
+ * @notice A contract that implements the MinterManagementInterface has external
+ * functions for adding and removing minters and modifying their allowances.
+ * An example is the FiatTokenV1 contract that implements USDC.
+ */
+interface MinterManagementInterface {
+    function isMinter(address _account) external view returns (bool);
+
+    function minterAllowance(address _minter) external view returns (uint256);
+
+    function configureMinter(address _minter, uint256 _minterAllowedAmount)
+        external
+        returns (bool);
+
+    function removeMinter(address _minter) external returns (bool);
+}

--- a/doc/masterminter.md
+++ b/doc/masterminter.md
@@ -1,0 +1,124 @@
+# MasterMinter contract
+
+The MasterMinter is a governance contract. It delegates the functionality of the
+`masterMinter` role in the CENTRE USDC contract to multiple addresses. (The
+`masterMinter` role can add and remove minters from a FiatToken and set their
+allowances.) The MasterMinter contract delegates the minter management
+capability to `controllers`. Each `controller` manages exactly one `minter`, and
+a single `minter` may be managed by multiple `controllers`. This allows
+separation of duties (off-line key management) and simplifies nonce management
+for warm transactions.
+
+Minters and FiatToken holders are not affected by replacing a `masterMinter`
+user address with a `MasterMinter` contract.
+
+# Roles
+
+The `MasterMinter` contract has the following roles:
+
+- `owner` - adds and removes controllers, sets the address of the
+  `minterManager`, and sets the owner.
+- `minterManager` - address of a contract (e.g. USDC) with a
+  `MinterManagementInterface`. The `minterManager` contract stores information
+  about minter allowances and which minters are enabled/disabled.
+- `controller` - each controller manages exactly one minter. A controller can
+  enable/disable its minter, and modify the minting allowance by calling
+  functions on the `MasterMinter` contract, and `MasterMinter` will call the
+  appropriate functions on the `minterManager`.
+- `minter` - each `minter` is managed by one or more `controller`. The `minter`
+  cannot perform any actions on the MasterMinter contract. It interacts only
+  with the FiatToken contract.
+
+# Interaction with FiatToken contract
+
+The `owner` of the FiatToken contract can set the `masterMinter` role to point
+to the address of the `MasterMinter` contract. This enables the `MasterMinter`
+contract to call minter management functions on the FiatToken contract:
+
+- `configureMinter(minter, allowance)` - Enables the `minter` and sets its
+  minting allowance.
+- `removeMinter(minter)` - Disables the `minter` and sets its minting allowance
+  to 0.
+- `isMinter(minter)` - Returns `true` if the `minter` is enabled, and `false`
+  otherwise.
+- `minterAllowance(minter)` - Returns the minting allowance of the `minter`.
+
+Together, these four functions are defined as the `MinterManagementInterface`.
+The `MasterMinter` contains the address of a `minterManager` that implements the
+`MinterManagementInterface`. The `MasterMinter` interacts with the USDC token
+via the `minterManager`.
+
+When a `controller` calls a function on `MasterMinter`, the `MasterMinter` will
+call the appropriate function on the `FiatToken` contract on its behalf. Both
+the `MasterMinter` and the `FiatToken` do their own access control.
+
+# Function Summary
+
+- `configureController(controller, minter)` - The owner assigns the controller
+  to manage the minter. This allows the `controller` to call `configureMinter`,
+  `incrementMinterAllowance` and `removeMinter`. Note:
+  `configureController(controller, 0x00)` is forbidden because it has the effect
+  of removing the controller.
+- `removeController(controller)` - The owner disables the controller by setting
+  its `minter` to `0x00`.
+- `setMinterManager(minterManager)` - The owner sets a new contract to the
+  `minterManager` address. This has no effect on the old `minterManager`
+  contract. If the new `minterManager` does not implement the
+  `MinterManagementInterface` or does not give this instance of the
+  `MasterMinter` contract permission to call minter management functions then
+  the `controller` calls to `configureMinter`, `incrementMinterAllowance`, and
+  `removeMinter` will throw.
+- `configureMinter(allowance)` - A controller enables its minter and sets its
+  allowance. The `MasterMinter` contract will call the `minterManager` contract
+  on the `controller`'s behalf.
+- `incrementMinterAllowance` - A controller increments the allowance of an
+  <b>enabled</b> minter (`incrementMinterAllowance` will throw if the `minter`
+  is disabled). The `MasterMinter` contract will call the `minterManager`
+  contract on the `controller`'s behalf.
+- `removeMinter` - A controller disables a `minter`. The `MasterMinter` contract
+  will call the `minterManager` contract on the `controller`'s behalf.
+
+# Deployment
+
+The `MasterMinter` may be deployed independently of the `FiatToken` contract
+(e.g. USDC).
+
+- <b>FiatToken</b> then <b>MasterMinter.</b> Deploy `MasterMinter` and set the
+  `minterManager` to point to the `FiatToken` in the constructor. Then use the
+  `MasterMinter` `owner` role to configure at least one `controller` for each
+  existing `minter` in the `FiatToken`. Once the `MasterMinter` is fully
+  configured, use the `FiatToken` `owner` role to broadcast an
+  `updateMasterMinter` transaction setting `masterMinter` role to the
+  `MasterMinter` contract address.
+- <b>MasterMinter</b> then <b>FiatToken.</b> Deploy `MasterMinter` and set the
+  `minterManager` to point to address `0x00` in the constructor. Then deploy the
+  `FiatToken` and set the `masterMinter` to be the address of the `MasterMinter`
+  contract in the constructor. Next, use the `MasterMinter` `owner` to set the
+  `minterManager` and configure `controllers`.
+
+# Configuring the MasterMinter
+
+We recommend assigning at least <b>two</b> `controllers` to each `minter`.
+
+- <b>AllowanceController.</b> Use this `controller` to enable the `minter` with
+  a single `configureMinter` transaction, and then use it exclusively to sign
+  `incrementMinterAllowance` transactions. There may be multiple
+  `AllowanceControllers` that sign different size allowance increment
+  transactions.
+- <b>SecurityController.</b> Use this `controller` to sign a single
+  `removeMinter` transaction and store it for emergencies.
+
+The private keys to the `AllowanceController` and `SecurityController` should
+stay in cold storage. This configuration lets the Controller keep multiple warm
+`incrementMinterAllowance` transactions on hand, as well as the `removeMinter`
+transaction in case of a problem. Broadcasting the `removeMinter` transaction
+will cause all future `incrementMinterAllowance` transactions to `throw`. Since
+the two types of transactions are managed by different addresses, there is no
+need to worry about nonce management.
+
+# MasterMinter vs. MintController
+
+Creating a `MasterMinter` contract that _inherits_ from a `MintController`
+contract with no changes may seem like a curious design choice. This leaves open
+the possibility of creating other contracts that inherit from `MintController`
+without creating naming confusion due to their different functionality.

--- a/migrations/7_deploy_master_minter.js
+++ b/migrations/7_deploy_master_minter.js
@@ -1,0 +1,24 @@
+const MasterMinter = artifacts.require("./MasterMinter.sol");
+const FiatToken = artifacts.require("./FiatTokenProxy.sol");
+let minterOwner;
+let fiatToken;
+
+module.exports = function (deployer, network) {
+  if (network === "development" || network === "coverage") {
+    // Change these if deploying for real, these are deterministic
+    // address from ganache
+    minterOwner = "0x3e5e9111ae8eb78fe1cc3bb8915d5d461f3ef9a9";
+    fiatToken = FiatToken.address;
+  }
+  console.log("deploying MasterMinter for fiat token at " + fiatToken);
+  deployer
+    .deploy(MasterMinter, fiatToken)
+    .then(function (mm) {
+      console.log("master minter deployed at " + mm.address);
+      console.log("reassigning owner to " + minterOwner);
+      return mm.transferOwnership(minterOwner);
+    })
+    .then(function () {
+      console.log("All done.");
+    });
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "url": "https://github.com/centrehq/centre-tokens/issues"
   },
   "homepage": "https://github.com/centrehq/centre-tokens#readme",
-  "dependencies": {},
+  "dependencies": {
+    "assert-diff": "1.2.6"
+  },
   "devDependencies": {
     "@openzeppelin/contracts": "^3.1.0",
     "@truffle/hdwallet-provider": "^1.0.39",

--- a/test/minting/AccountUtils.js
+++ b/test/minting/AccountUtils.js
@@ -1,0 +1,185 @@
+// set to true to enable verbose logging in the tests
+const debugLogging = false;
+const assertDiff = require("assert-diff");
+assertDiff.options.strict = true;
+
+const Q = require("q");
+const clone = require("clone");
+const util = require("util");
+
+// named list of all accounts
+const Accounts = {
+  deployerAccount: "0x90F8BF6A479F320EAD074411A4B0E7944EA8C9C1", // accounts[0]
+  arbitraryAccount: "0xFFCF8FDEE72AC11B5C542428B35EEF5769C409F0", // accounts[1]
+  tokenOwnerAccount: "0xE11BA2B4D45EAED5996CD0823791E0C93114882D", // Accounts.arbitraryAccount
+  blacklisterAccount: "0xD03EA8624C8C5987235048901FB614FDCA89B117", // accounts[4]
+  arbitraryAccount2: "0x95CED938F7991CD0DFCB48F0A06A40FA1AF46EBC", // accounts[5]
+  masterMinterAccount: "0x3E5E9111AE8EB78FE1CC3BB8915D5D461F3EF9A9", // accounts[6]
+  minterAccount: "0x28A8746E75304C0780E011BED21C72CD78CD535E", // accounts[7]
+  pauserAccount: "0xACA94EF8BD5FFEE41947B4585A84BDA5A3D3DA6E", // accounts[8]
+  mintOwnerAccount: "0x1DF62F291B2E969FB0849D99D9CE41E2F137006E", // accounts[9]
+  controller1Account: "0x855FA758C77D68A04990E992AA4DCDEF899F654A", // accounts[11]
+  proxyOwnerAccount: "0x2F560290FEF1B3ADA194B6AA9C40AA71F8E95598", // accounts[14]
+};
+
+// named list of known private keys
+const AccountPrivateKeys = {
+  deployerPrivateKey:
+    "4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d", // accounts[0]
+  arbitraryPrivateKey:
+    "6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1", // accounts[1]
+  issuerControllerPrivateKey:
+    "6370fd033278c143179d81c5526140625662b8daa446c22ee2d73db3707e620c", // accounts[2]
+  tokenOwnerPrivateKey:
+    "646f1ce2fdad0e6deeeb5c7e8e5543bdde65e86029e2fd9fc169899c440a7913", // Accounts.arbitraryAccount
+  blacklisterPrivateKey:
+    "add53f9a7e588d003326d1cbf9e4a43c061aadd9bc938c843a79e7b4fd2ad743", // accounts[4]
+  arbitrary2PrivateKey:
+    "395df67f0c2d2d9fe1ad08d1bc8b6627011959b79c53d7dd6a3536a33ab8a4fd", // accounts[5]
+  masterMinterPrivateKey:
+    "e485d098507f54e7733a205420dfddbe58db035fa577fc294ebd14db90767a52", // accounts[6]
+  minterPrivateKeyt:
+    "a453611d9419d0e56f499079478fd72c37b251a94bfde4d19872c44cf65386e3", // accounts[7]
+  pauserPrivateKey:
+    "829e924fdf021ba3dbbc4225edfece9aca04b929d6e75613329ca6f1d31c0bb4", // accounts[8]
+  mintOwnerPrivateKey:
+    "b0057716d5917badaf911b193b12b910811c1497b5bada8d7711f758981c3773", // accounts[9]
+  mintProtectorPrivateKey:
+    "77c5495fbb039eed474fc940f29955ed0531693cc9212911efd35dff0373153f", // accounts[10]
+  controller1PrivateKey:
+    "d99b5b29e6da2528bf458b26237a6cf8655a3e3276c1cdc0de1f98cefee81c01", // accounts[11]
+  controller2PrivateKey:
+    "9b9c613a36396172eab2d34d72331c8ca83a358781883a535d2941f66db07b24", // accounts[12]
+  issuerOwnerPrivateKey:
+    "0874049f95d55fb76916262dc70571701b5c4cc5900c0691af75f1a8a52c8268", // accounts[13]
+  proxyOwnerAccount:
+    "21d7212f3b4e5332fd465877b64926e3532653e2798a11255a46f533852dfe46", // accounts[14]
+};
+
+function addressEquals(address1, address2) {
+  if (address1.toUpperCase() === address2.toUpperCase()) {
+    return true;
+  } else {
+    assert.isFalse("expect " + address1 + " to equal " + address2);
+  }
+}
+
+// Returns an object with all named account values set to the default value
+// e.g sets {owner: 0, minter: 0,...}
+function setAccountDefault(accounts, defaultValue) {
+  const result = {};
+  for (const accountName in accounts) {
+    result[accountName] = defaultValue;
+  }
+  return result;
+}
+
+// return an expectedState that combines customState with the emptyState
+function buildExpectedPartialState(
+  emptyState,
+  customState,
+  ignoreExtraCustomVars
+) {
+  // for each item in customVars, set the item in expectedState
+  const expectedState = clone(emptyState);
+
+  for (const variableName in customState) {
+    // do I ignore extra values
+    if (Object.prototype.hasOwnProperty.call(expectedState, variableName)) {
+      const variableValue = customState[variableName];
+      if (isLiteral(variableValue)) {
+        expectedState[variableName] = variableValue;
+      } else {
+        // assume variableValue is a mapping evaluated on 1 or more accounts
+        for (const accountName in variableValue) {
+          expectedState[variableName][accountName] = variableValue[accountName];
+        }
+      }
+    } else if (!ignoreExtraCustomVars) {
+      throw new Error(
+        "variable " + variableName + " not found in expectedState"
+      );
+    }
+  }
+  return expectedState;
+}
+
+// For testing variance of specific variables from their default values.
+// customVars is an array of objects of the form,
+// {'variable': <name of variable>, 'expectedValue': <expected value after modification>}
+// to reference nested variables, name variable using dot syntax, e.g. 'allowance.arbitraryAccount.minterAccount'
+// emptyState: is the ideal empty state
+// getActualState: async function(token, accounts) => state
+// accounts: list of accounts on which to evaluate mappings
+// ignoreExtraCustomVars: ignore _customVars names that are not in the emptyState
+async function checkState(
+  _tokens,
+  _customVars,
+  emptyState,
+  getActualState,
+  accounts,
+  ignoreExtraCustomVars
+) {
+  // Iterate over array of tokens.
+  const numTokens = _tokens.length;
+  assert.equal(numTokens, _customVars.length);
+  let n;
+  for (n = 0; n < numTokens; n++) {
+    const token = _tokens[n];
+    const customVars = _customVars[n];
+    const expectedState = buildExpectedPartialState(
+      emptyState,
+      customVars,
+      ignoreExtraCustomVars
+    );
+
+    if (debugLogging) {
+      console.log(
+        util.inspect(expectedState, { showHidden: false, depth: null })
+      );
+    }
+
+    const actualState = await getActualState(token, accounts);
+    assertDiff.deepEqual(
+      actualState,
+      expectedState,
+      "difference between expected and actual state"
+    );
+  }
+}
+
+// accountQuery: an async function that takes as input an address and
+//       queries the blockchain for a result
+// accounts: an object containing account addresses.  Eg: {owner: 0xffad9033, minter: 0x45289432}
+// returns an object containing the results of calling accountQuery on each account
+//        E.g. {owner: value1, minter: value2}
+async function getAccountState(accountQuery, accounts) {
+  // create an array of promises
+  const promises = [];
+  for (const account in accounts) {
+    const promiseQuery = accountQuery(Accounts[account]);
+    promises.push(promiseQuery);
+  }
+  const results = await Q.allSettled(promises);
+  const state = {};
+  let u = 0;
+  for (const account in accounts) {
+    state[account] = results[u].value;
+    ++u;
+  }
+  return state;
+}
+
+function isLiteral(object) {
+  if (typeof object === "object" && !object._isBigNumber) return false;
+  return true;
+}
+
+module.exports = {
+  Accounts: Accounts,
+  AccountPrivateKeys: AccountPrivateKeys,
+  setAccountDefault: setAccountDefault,
+  checkState: checkState,
+  getAccountState: getAccountState,
+  addressEquals: addressEquals,
+};

--- a/test/minting/ControllerTestUtils.js
+++ b/test/minting/ControllerTestUtils.js
@@ -1,0 +1,49 @@
+const Q = require("q");
+
+const AccountUtils = require("./AccountUtils.js");
+const Accounts = AccountUtils.Accounts;
+const setAccountDefault = AccountUtils.setAccountDefault;
+const checkState = AccountUtils.checkState;
+const getAccountState = AccountUtils.getAccountState;
+
+function ControllerState(owner, controllers) {
+  this.owner = owner;
+  this.controllers = controllers;
+  this.checkState = async function (controllerContract) {
+    await checkControllerState(controllerContract, this);
+  };
+}
+
+// Default state of Controller when it is deployed
+const controllerEmptyState = new ControllerState(
+  Accounts.mintOwnerAccount,
+  setAccountDefault(Accounts, "0x0000000000000000000000000000000000000000")
+);
+
+// Checks the state of an array of controller contracts
+async function checkControllerState(controller, customState) {
+  await checkState(
+    controller,
+    customState,
+    controllerEmptyState,
+    getActualControllerState,
+    Accounts,
+    true
+  );
+}
+
+// Gets the actual state of the controller contract.
+// Evaluates all mappings on the provided accounts.
+async function getActualControllerState(controllerContract, accounts) {
+  return Q.all([
+    controllerContract.owner.call(),
+    getAccountState(controllerContract.controllers, accounts),
+  ]).spread(function (owner, controllerState) {
+    return new ControllerState(owner, controllerState);
+  });
+}
+
+module.exports = {
+  controllerEmptyState: controllerEmptyState,
+  checkControllerState: checkControllerState,
+};

--- a/test/minting/MintControllerTests.js
+++ b/test/minting/MintControllerTests.js
@@ -1,0 +1,342 @@
+const MintController = artifacts.require("minting/MintController");
+
+const tokenUtils = require("../v1/TokenTestUtils.js");
+const newBigNumber = tokenUtils.newBigNumber;
+const checkMINTp0 = tokenUtils.checkMINTp0;
+const expectRevert = tokenUtils.expectRevert;
+const expectError = tokenUtils.expectError;
+const bigZero = tokenUtils.bigZero;
+
+const clone = require("clone");
+
+const mintUtils = require("./MintControllerUtils.js");
+const AccountUtils = require("./AccountUtils.js");
+const Accounts = AccountUtils.Accounts;
+const initializeTokenWithProxyAndMintController =
+  mintUtils.initializeTokenWithProxyAndMintController;
+
+let rawToken;
+let tokenConfig;
+let token;
+let mintController;
+let expectedMintControllerState;
+let expectedTokenState;
+
+async function run_tests(newToken) {
+  beforeEach("Make fresh token contract", async function () {
+    rawToken = await newToken();
+    tokenConfig = await initializeTokenWithProxyAndMintController(
+      rawToken,
+      MintController
+    );
+    token = tokenConfig.token;
+    mintController = tokenConfig.mintController;
+    expectedMintControllerState = clone(tokenConfig.customState);
+    expectedTokenState = [
+      { variable: "masterMinter", expectedValue: mintController.address },
+    ];
+  });
+
+  it("should mint through mint controller", async function () {
+    const amount = 5000;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+
+    await token.mint(Accounts.arbitraryAccount, amount, {
+      from: Accounts.minterAccount,
+    });
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "balances.arbitraryAccount",
+        expectedValue: newBigNumber(amount),
+      },
+      { variable: "totalSupply", expectedValue: newBigNumber(amount) }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("initial state", async function () {
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("only owner configures controller", async function () {
+    await expectRevert(
+      mintController.configureController(
+        Accounts.controller1Account,
+        Accounts.minterAccount,
+        { from: Accounts.minterAccount }
+      )
+    );
+  });
+
+  it("remove controller", async function () {
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    await mintController.removeController(Accounts.controller1Account, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.controllers.controller1Account = bigZero;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("only owner can remove controller", async function () {
+    await expectRevert(
+      mintController.removeController(Accounts.controller1Account, {
+        from: Accounts.minterAccount,
+      })
+    );
+  });
+
+  it("sets token", async function () {
+    await mintController.setMinterManager(mintController.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = mintController.address;
+    checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("only owner sets token", async function () {
+    await expectRevert(
+      mintController.setMinterManager(mintController.address, {
+        from: Accounts.minterAccount,
+      })
+    );
+  });
+
+  it("remove minter", async function () {
+    // create a minter
+    const amount = 500;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(amount),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // remove minter
+    await mintController.removeMinter({ from: Accounts.controller1Account });
+    expectedTokenState = [
+      { variable: "masterMinter", expectedValue: mintController.address },
+    ];
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("only controller removes a minter", async function () {
+    await expectError(
+      mintController.removeMinter({ from: Accounts.controller1Account }),
+      "The value of controllers[msg.sender] must be non-zero"
+    );
+  });
+
+  it("only controller configures a minter", async function () {
+    await expectError(
+      mintController.configureMinter(0, { from: Accounts.controller1Account }),
+      "The value of controllers[msg.sender] must be non-zero"
+    );
+  });
+
+  it("increment minter allowance", async function () {
+    // configure controller & minter
+    const amount = 500;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(amount),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // increment minter allowance
+    await mintController.incrementMinterAllowance(amount, {
+      from: Accounts.controller1Account,
+    });
+    expectedTokenState = [
+      { variable: "masterMinter", expectedValue: mintController.address },
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(amount * 2),
+      },
+    ];
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("only controller increments allowance", async function () {
+    await expectError(
+      mintController.incrementMinterAllowance(0, {
+        from: Accounts.controller1Account,
+      }),
+      "The value of controllers[msg.sender] must be non-zero"
+    );
+  });
+
+  it("only active minters can have allowance incremented", async function () {
+    // configure controller but not minter
+    const amount = 500;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // increment minter allowance
+    await expectError(
+      mintController.incrementMinterAllowance(amount, {
+        from: Accounts.controller1Account,
+      }),
+      "Can only increment allowance for minters in minterManager"
+    );
+  });
+
+  it("decrement minter allowance", async function () {
+    // configure controller & minter
+    const amount = 500;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(amount),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // decrement minter allowance
+    await mintController.decrementMinterAllowance(amount, {
+      from: Accounts.controller1Account,
+    });
+    expectedTokenState = [
+      { variable: "masterMinter", expectedValue: mintController.address },
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      { variable: "minterAllowance.minterAccount", expectedValue: bigZero },
+    ];
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("only controller decrements allowance", async function () {
+    await expectError(
+      mintController.decrementMinterAllowance(0, {
+        from: Accounts.controller1Account,
+      }),
+      "The value of controllers[msg.sender] must be non-zero"
+    );
+  });
+
+  it("only active minters can have allowance decremented", async function () {
+    // configure controller but not minter
+    const amount = 500;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // decrement minter allowance
+    await expectError(
+      mintController.decrementMinterAllowance(amount, {
+        from: Accounts.controller1Account,
+      }),
+      "Can only decrement allowance for minters in minterManager"
+    );
+  });
+}
+
+const wrapTests = require("../v1/helpers/wrapTests");
+wrapTests("MintController_Tests MintController", run_tests);
+
+module.exports = {
+  run_tests: run_tests,
+};

--- a/test/minting/MintControllerUtils.js
+++ b/test/minting/MintControllerUtils.js
@@ -1,0 +1,71 @@
+const tokenUtils = require("../v1/TokenTestUtils.js");
+const bigZero = tokenUtils.bigZero;
+const initializeTokenWithProxy = tokenUtils.initializeTokenWithProxy;
+
+const AccountUtils = require("./AccountUtils.js");
+const Accounts = AccountUtils.Accounts;
+const checkState = AccountUtils.checkState;
+
+const ControllerUtils = require("./ControllerTestUtils.js");
+const checkControllerState = ControllerUtils.checkControllerState;
+
+function MintControllerState(owner, controllers, minterManager) {
+  this.owner = owner;
+  this.controllers = controllers;
+  this.minterManager = minterManager;
+  this.checkState = async function (mintController) {
+    await checkMintControllerState(mintController, this);
+  };
+}
+
+// Default state of MintController when it is deployed
+const mintControllerEmptyState = new MintControllerState(null, {}, bigZero);
+
+// Checks the state of the mintController contract
+async function checkMintControllerState(mintController, customState) {
+  await checkControllerState(mintController, customState);
+  await checkState(
+    mintController,
+    customState,
+    mintControllerEmptyState,
+    getActualMintControllerState,
+    Accounts,
+    true
+  );
+}
+
+// Gets the actual state of the mintController contract.
+// Evaluates all mappings on the provided accounts.
+async function getActualMintControllerState(mintController) {
+  const minterManager = await mintController.minterManager.call();
+  return new MintControllerState(null, {}, minterManager);
+}
+
+// Deploys a FiatTokenV1 with a MintController contract as the masterMinter.
+// Uses the same workflow we would do in production - first deploy FiatToken then set the masterMinter.
+async function initializeTokenWithProxyAndMintController(
+  rawToken,
+  MintControllerArtifact
+) {
+  const tokenConfig = await initializeTokenWithProxy(rawToken);
+  const mintController = await MintControllerArtifact.new(
+    tokenConfig.token.address,
+    { from: Accounts.mintOwnerAccount }
+  );
+  await tokenConfig.token.updateMasterMinter(mintController.address, {
+    from: Accounts.tokenOwnerAccount,
+  });
+  const tokenConfigWithMinter = {
+    proxy: tokenConfig.proxy,
+    token: tokenConfig.token,
+    mintController: mintController,
+    customState: new MintControllerState(null, {}, tokenConfig.token.address),
+  };
+  return tokenConfigWithMinter;
+}
+
+module.exports = {
+  initializeTokenWithProxyAndMintController: initializeTokenWithProxyAndMintController,
+  checkMintControllerState: checkMintControllerState,
+  MintControllerState: MintControllerState,
+};

--- a/test/minting/MultiIssuerArgumentTests.js
+++ b/test/minting/MultiIssuerArgumentTests.js
@@ -1,0 +1,478 @@
+const MintController = artifacts.require("minting/MintController");
+const MasterMinter = artifacts.require("minting/MasterMinter");
+const FiatToken = artifacts.require("FiatTokenV1");
+
+const tokenUtils = require("../v1/TokenTestUtils");
+const newBigNumber = tokenUtils.newBigNumber;
+const checkMINTp0 = tokenUtils.checkMINTp0;
+const expectRevert = tokenUtils.expectRevert;
+const expectError = tokenUtils.expectError;
+const bigZero = tokenUtils.bigZero;
+
+const clone = require("clone");
+
+const mintUtils = require("./MintControllerUtils.js");
+const AccountUtils = require("./AccountUtils.js");
+const Accounts = AccountUtils.Accounts;
+const addressEquals = AccountUtils.addressEquals;
+const initializeTokenWithProxyAndMintController =
+  mintUtils.initializeTokenWithProxyAndMintController;
+
+const zeroAddress = "0x0000000000000000000000000000000000000000";
+const maxAmount =
+  "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+
+async function run_tests_MintController(newToken, accounts) {
+  run_MINT_tests(newToken, MintController, accounts);
+}
+
+async function run_tests_MasterMinter(newToken, accounts) {
+  run_MINT_tests(newToken, MasterMinter, accounts);
+}
+
+let rawToken;
+let tokenConfig;
+let token;
+let mintController;
+let expectedMintControllerState;
+let expectedTokenState;
+
+async function run_MINT_tests(newToken, MintControllerArtifact) {
+  beforeEach("Make fresh token contract", async function () {
+    rawToken = await newToken();
+    tokenConfig = await initializeTokenWithProxyAndMintController(
+      rawToken,
+      MintControllerArtifact
+    );
+    token = tokenConfig.token;
+    mintController = tokenConfig.mintController;
+    expectedMintControllerState = clone(tokenConfig.customState);
+    expectedTokenState = [
+      { variable: "masterMinter", expectedValue: mintController.address },
+    ];
+  });
+
+  it("arg000 transferOwnership(msg.sender) works", async function () {
+    await mintController.transferOwnership(Accounts.mintOwnerAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg001 transferOwnership(0) reverts", async function () {
+    await expectRevert(
+      mintController.transferOwnership(zeroAddress, {
+        from: Accounts.mintOwnerAccount,
+      })
+    );
+  });
+
+  it("arg002 transferOwnership(owner) works", async function () {
+    await mintController.transferOwnership(Accounts.mintOwnerAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg003 configureController(0, M) throws", async function () {
+    await expectError(
+      mintController.configureController(zeroAddress, Accounts.minterAccount, {
+        from: Accounts.mintOwnerAccount,
+      }),
+      "Controller must be a non-zero address"
+    );
+  });
+
+  it("arg004 configureController(msg.sender, M) works", async function () {
+    await mintController.configureController(
+      Accounts.mintOwnerAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.mintOwnerAccount =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg005 configureController(M, M) works", async function () {
+    await mintController.configureController(
+      Accounts.minterAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.minterAccount =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg006 configureController(C, 0) throws", async function () {
+    await expectError(
+      mintController.configureController(
+        Accounts.controller1Account,
+        zeroAddress,
+        { from: Accounts.mintOwnerAccount }
+      ),
+      "Worker must be a non-zero address"
+    );
+  });
+
+  it("arg007 removeController(0) throws", async function () {
+    // expect no changes
+    await expectError(
+      mintController.removeController(zeroAddress, {
+        from: Accounts.mintOwnerAccount,
+      }),
+      "Controller must be a non-zero address"
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg008 setMinterManager(0) works", async function () {
+    await mintController.setMinterManager(zeroAddress, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = zeroAddress;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg009 setMinterManager(oldMinterManager) works", async function () {
+    await mintController.setMinterManager(token.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = token.address;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg010 setMinterManager(user_account) works", async function () {
+    await mintController.setMinterManager(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = Accounts.arbitraryAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg011 setMinterManager(newToken) works", async function () {
+    const newToken = await FiatToken.new();
+    await mintController.setMinterManager(newToken.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = newToken.address;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg012 configureMinter(0) sets allowance to 0", async function () {
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(0, {
+      from: Accounts.controller1Account,
+    });
+
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(0),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg013 configureMinter(oldAllowance) makes no changes", async function () {
+    const oldAllowance = 64738;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(oldAllowance, {
+      from: Accounts.controller1Account,
+    });
+    await mintController.configureMinter(oldAllowance, {
+      from: Accounts.controller1Account,
+    });
+
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(oldAllowance),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg014 configureMinter(MAX) works", async function () {
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(maxAmount, {
+      from: Accounts.controller1Account,
+    });
+
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(maxAmount),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg015 incrementMinterAllowance(0) throws", async function () {
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await expectError(
+      mintController.incrementMinterAllowance(0, {
+        from: Accounts.controller1Account,
+      }),
+      "Allowance increment must be greater than 0"
+    );
+  });
+
+  it("arg016 incrementMinterAllowance(oldAllowance) doubles the allowance", async function () {
+    const amount = 897;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    await mintController.incrementMinterAllowance(amount, {
+      from: Accounts.controller1Account,
+    });
+
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(2 * amount),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg017 incrementMinterAllowance(MAX) throws", async function () {
+    const amount = 1;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    await expectRevert(
+      mintController.incrementMinterAllowance(maxAmount, {
+        from: Accounts.controller1Account,
+      })
+    );
+  });
+
+  it("arg018 incrementMinterAllowance(BIG) throws", async function () {
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(maxAmount, {
+      from: Accounts.controller1Account,
+    });
+    await expectRevert(
+      mintController.incrementMinterAllowance(1, {
+        from: Accounts.controller1Account,
+      })
+    );
+  });
+
+  it("arg019 configureController(0, 0) throws", async function () {
+    await expectError(
+      mintController.configureController(zeroAddress, zeroAddress, {
+        from: Accounts.mintOwnerAccount,
+      }),
+      "Controller must be a non-zero address"
+    );
+  });
+
+  it("arg020 removeController(C) works", async function () {
+    // make controller1Account a controller
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    let actualMinter = await mintController.getWorker(
+      Accounts.controller1Account
+    );
+    addressEquals(Accounts.minterAccount, actualMinter);
+
+    // remove controller1Account
+    await mintController.removeController(Accounts.controller1Account, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+    actualMinter = await mintController.getWorker(Accounts.controller1Account);
+    addressEquals(actualMinter, zeroAddress);
+  });
+
+  it("arg021 removeController throws if worker is already address(0)", async function () {
+    // make controller1Account a controller
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    let actualMinter = await mintController.getWorker(
+      Accounts.controller1Account
+    );
+    addressEquals(Accounts.minterAccount, actualMinter);
+
+    // remove controller1Account
+    await mintController.removeController(Accounts.controller1Account, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+    actualMinter = await mintController.getWorker(Accounts.controller1Account);
+    addressEquals(actualMinter, zeroAddress);
+
+    // attempting to remove the controller1Account again should throw because the worker is already set to address(0).
+    await expectError(
+      mintController.removeController(Accounts.controller1Account, {
+        from: Accounts.mintOwnerAccount,
+      }),
+      "Worker must be a non-zero address"
+    );
+  });
+
+  it("arg022 decrementMinterAllowance(oldAllowance) sets the allowance to 0", async function () {
+    const amount = 897;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    await mintController.decrementMinterAllowance(amount, {
+      from: Accounts.controller1Account,
+    });
+
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      { variable: "minterAllowance.minterAccount", expectedValue: bigZero }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg023 decrementMinterAllowance(MIN) sets the allowance to 0", async function () {
+    const amount = 0;
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(amount, {
+      from: Accounts.controller1Account,
+    });
+    await mintController.decrementMinterAllowance(1, {
+      from: Accounts.controller1Account,
+    });
+    expectedMintControllerState.controllers.controller1Account =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      { variable: "minterAllowance.minterAccount", expectedValue: bigZero }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("arg024 decrementMinterAllowance(0) throws", async function () {
+    await mintController.configureController(
+      Accounts.controller1Account,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await expectError(
+      mintController.decrementMinterAllowance(0, {
+        from: Accounts.controller1Account,
+      }),
+      "Allowance decrement must be greater than 0"
+    );
+  });
+}
+
+const wrapTests = require("../v1/helpers/wrapTests");
+wrapTests("MINTp0_ArgumentTests MintController", run_tests_MintController);
+wrapTests("MINTp0_ArgumentTests MasterMinter", run_tests_MasterMinter);

--- a/test/minting/MultiIssuerEvents.js
+++ b/test/minting/MultiIssuerEvents.js
@@ -1,0 +1,326 @@
+const MintController = artifacts.require("minting/MintController");
+const MasterMinter = artifacts.require("minting/MasterMinter");
+
+const mintUtils = require("./MintControllerUtils.js");
+const AccountUtils = require("./AccountUtils.js");
+const Accounts = AccountUtils.Accounts;
+const initializeTokenWithProxyAndMintController =
+  mintUtils.initializeTokenWithProxyAndMintController;
+
+let rawToken;
+let tokenConfig;
+let token;
+let mintController;
+
+const mintControllerEvents = {
+  ownershipTransferred: "OwnershipTransferred",
+  controllerConfigured: "ControllerConfigured",
+  controllerRemoved: "ControllerRemoved",
+  minterManagerSet: "MinterManagerSet",
+  minterCofigured: "MinterConfigured",
+  minterRemoved: "MinterRemoved",
+  minterAllowanceIncremented: "MinterAllowanceIncremented",
+  minterAllowanceDecremented: "MinterAllowanceDecremented",
+};
+
+async function run_tests_MintController(newToken, accounts) {
+  run_MINT_tests(newToken, MintController, accounts);
+}
+
+async function run_tests_MasterMinter(newToken, accounts) {
+  run_MINT_tests(newToken, MasterMinter, accounts);
+}
+
+async function run_MINT_tests(newToken, MintControllerArtifact) {
+  beforeEach("Make fresh token contract", async function () {
+    rawToken = await newToken();
+    tokenConfig = await initializeTokenWithProxyAndMintController(
+      rawToken,
+      MintControllerArtifact
+    );
+    token = tokenConfig.token;
+    mintController = tokenConfig.mintController;
+  });
+
+  it("et100 transferOwnership emits OwnershipTransferred event", async function () {
+    // get all previous transfer ownership events
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.ownershipTransferred,
+      {
+        filter: {
+          previousOwner: Accounts.mintOwnerAccount,
+          newOwner: Accounts.arbitraryAccount,
+        },
+      }
+    );
+
+    // now transfer ownership and test again
+    await mintController.transferOwnership(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.ownershipTransferred,
+      {
+        filter: {
+          previousOwner: Accounts.mintOwnerAccount,
+          newOwner: Accounts.arbitraryAccount,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et101 configureController emits ControllerConfigured event", async function () {
+    // get all previous configure controller events
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.controllerConfigured,
+      {
+        filter: {
+          _controller: Accounts.arbitraryAccount,
+          _worker: Accounts.arbitraryAccount2,
+        },
+      }
+    );
+
+    // now configure controller and test again
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.arbitraryAccount2,
+      { from: Accounts.mintOwnerAccount }
+    );
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.controllerConfigured,
+      {
+        filter: {
+          _controller: Accounts.arbitraryAccount,
+          _worker: Accounts.arbitraryAccount2,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et102 removeController emits ControllerRemoved event", async function () {
+    // get all previous removeController events
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.arbitraryAccount2,
+      { from: Accounts.mintOwnerAccount }
+    );
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.controllerRemoved,
+      { filter: { _controller: Accounts.arbitraryAccount } }
+    );
+
+    // now remove controller and test again
+    await mintController.removeController(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.controllerRemoved,
+      { filter: { _controller: Accounts.arbitraryAccount } }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et103 setMinterManager emits MinterManagerSet event", async function () {
+    // get all previous set minter manager events
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterManagerSet,
+      {
+        filter: {
+          _oldMinterManager: token.address,
+          _newMinterManager: Accounts.arbitraryAccount,
+        },
+      }
+    );
+
+    // now set minter manager and test again
+    await mintController.setMinterManager(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterManagerSet,
+      {
+        filter: {
+          _oldMinterManager: token.address,
+          _newMinterManager: Accounts.arbitraryAccount,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et104 removeMinter emits MinterRemoved event", async function () {
+    // get all previous remove minter events
+    const allowance = 10;
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(allowance, {
+      from: Accounts.arbitraryAccount,
+    });
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterRemoved,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+        },
+      }
+    );
+
+    // now remove minter and test again
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterRemoved,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et105 configureMinter emits MinterConfigured event", async function () {
+    // get all previous configureMinter events
+    const allowance = 10;
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterCofigured,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+          _allowance: allowance,
+        },
+      }
+    );
+
+    // now transfer ownership and test again
+    await mintController.configureMinter(allowance, {
+      from: Accounts.arbitraryAccount,
+    });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterCofigured,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+          _allowance: allowance,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et106 incrementMinterAllowance emits MinterAllowanceIncremented event", async function () {
+    // get all previous increment minter allowance events
+    const allowance = 10;
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(allowance, {
+      from: Accounts.arbitraryAccount,
+    });
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterAllowanceIncremented,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+          _increment: allowance,
+          _newAllowance: allowance * 2,
+        },
+      }
+    );
+
+    // now increment minter allowance and test again
+    await mintController.incrementMinterAllowance(allowance, {
+      from: Accounts.arbitraryAccount,
+    });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterAllowanceIncremented,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+          _increment: allowance,
+          _newAllowance: allowance * 2,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+
+  it("et107 decrementMinterAllowance emits MinterAllowanceDecremented event", async function () {
+    // get all previous decrement minter allowance events
+    const allowance = 10;
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(allowance, {
+      from: Accounts.arbitraryAccount,
+    });
+    const preEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterAllowanceDecremented,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+          _decrement: allowance,
+          _newAllowance: 0,
+        },
+      }
+    );
+
+    // now decrement minter allowance and test again
+    await mintController.decrementMinterAllowance(allowance, {
+      from: Accounts.arbitraryAccount,
+    });
+    const postEvents = await mintController.getPastEvents(
+      mintControllerEvents.minterAllowanceDecremented,
+      {
+        filter: {
+          _msgSender: Accounts.arbitraryAccount,
+          _minter: Accounts.minterAccount,
+          _decrement: allowance,
+          _newAllowance: 0,
+        },
+      }
+    );
+
+    // one new event must have fired
+    assert.equal(preEvents.length + 1, postEvents.length);
+  });
+}
+
+const wrapTests = require("../v1/helpers/wrapTests");
+wrapTests("MINTp0_EventTests MintController", run_tests_MintController);
+wrapTests("MINTp0_EventTests MasterMinter", run_tests_MasterMinter);

--- a/test/minting/MultiIssuerMinting.js
+++ b/test/minting/MultiIssuerMinting.js
@@ -1,0 +1,658 @@
+const MintController = artifacts.require("minting/MintController");
+const MasterMinter = artifacts.require("minting/MasterMinter");
+
+const tokenUtils = require("../v1/TokenTestUtils.js");
+const newBigNumber = tokenUtils.newBigNumber;
+const checkMINTp0 = tokenUtils.checkMINTp0;
+const expectRevert = tokenUtils.expectRevert;
+const expectError = tokenUtils.expectError;
+const initializeTokenWithProxy = tokenUtils.initializeTokenWithProxy;
+
+const clone = require("clone");
+
+const mintUtils = require("../minting/MintControllerUtils.js");
+const AccountUtils = require("../minting/AccountUtils.js");
+const Accounts = AccountUtils.Accounts;
+const initializeTokenWithProxyAndMintController =
+  mintUtils.initializeTokenWithProxyAndMintController;
+
+let mintController;
+let expectedMintControllerState;
+let expectedTokenState;
+let token;
+let rawToken;
+let tokenConfig;
+
+async function run_tests_MintController(newToken, accounts) {
+  run_MINT_tests(newToken, MintController, accounts);
+}
+
+async function run_tests_MasterMinter(newToken, accounts) {
+  run_MINT_tests(newToken, MasterMinter, accounts);
+}
+
+async function run_MINT_tests(newToken, MintControllerArtifact) {
+  beforeEach("Make fresh token contract", async function () {
+    rawToken = await newToken();
+    tokenConfig = await initializeTokenWithProxyAndMintController(
+      rawToken,
+      MintControllerArtifact
+    );
+    token = tokenConfig.token;
+    mintController = tokenConfig.mintController;
+    expectedMintControllerState = clone(tokenConfig.customState);
+    expectedTokenState = [
+      { variable: "masterMinter", expectedValue: mintController.address },
+    ];
+  });
+
+  it("ete000 New owner can configure controllers", async function () {
+    await mintController.transferOwnership(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await mintController.configureController(
+      Accounts.arbitraryAccount2,
+      Accounts.minterAccount,
+      { from: Accounts.arbitraryAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount2 =
+      Accounts.minterAccount;
+    expectedMintControllerState.owner = Accounts.arbitraryAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete001 New owner can remove controllers", async function () {
+    await mintController.transferOwnership(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await mintController.configureController(
+      Accounts.arbitraryAccount2,
+      Accounts.minterAccount,
+      { from: Accounts.arbitraryAccount }
+    );
+    await mintController.removeController(Accounts.arbitraryAccount2, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedMintControllerState.owner = Accounts.arbitraryAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete002 New controller can configure minter", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete003 Configure two controllers for the same minter and make sure they can both configureMinter", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureController(
+      Accounts.arbitraryAccount2,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedMintControllerState.controllers.arbitraryAccount2 =
+      Accounts.minterAccount;
+
+    // first controller configures minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // second controller configures minter
+    await mintController.configureMinter(30, {
+      from: Accounts.arbitraryAccount2,
+    });
+    expectedTokenState.push({
+      variable: "minterAllowance.minterAccount",
+      expectedValue: newBigNumber(30),
+    });
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete004 Configure two controllers for the same minter, one adds a minter and the other removes it", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureController(
+      Accounts.arbitraryAccount2,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedMintControllerState.controllers.arbitraryAccount2 =
+      Accounts.minterAccount;
+
+    // first controller configures minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // second controller remove minter
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount2 });
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: false },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(0),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete005 Configure two controllers for different minters and make sure 2nd cant remove", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureController(
+      Accounts.arbitraryAccount2,
+      Accounts.pauserAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedMintControllerState.controllers.arbitraryAccount2 =
+      Accounts.minterAccount;
+
+    // first controller configures minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // second controller fails to remove minter (expectedTokenState unchanged)
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount2 });
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete006 Configure two controllers for different minters and make sure 2nd cant configure", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureController(
+      Accounts.arbitraryAccount2,
+      Accounts.pauserAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedMintControllerState.controllers.arbitraryAccount2 =
+      Accounts.minterAccount;
+
+    // second controller fails to configure minter (configures pauser instead)
+    await mintController.configureMinter(20, {
+      from: Accounts.arbitraryAccount2,
+    });
+    expectedTokenState.push(
+      { variable: "isAccountMinter.pauserAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.pauserAccount",
+        expectedValue: newBigNumber(20),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete007 Remove a controller and make sure it can't modify minter", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.removeController(Accounts.arbitraryAccount, {
+      from: Accounts.mintOwnerAccount,
+    });
+    await expectError(
+      mintController.configureMinter(10, { from: Accounts.arbitraryAccount }),
+      "The value of controllers[msg.sender] must be non-zero"
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete008 Change minter manager and make sure existing controllers still can configure their minters", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+
+    // change minterManager to a new token
+    const newTokenConfig = await initializeTokenWithProxy(rawToken);
+    const newToken = newTokenConfig.token;
+    await newToken.updateMasterMinter(mintController.address, {
+      from: Accounts.tokenOwnerAccount,
+    });
+    await mintController.setMinterManager(newToken.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = newToken.address;
+
+    // now use controller to configure minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [newToken, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete009 Change minter manager and make sure existing controllers still can remove their minters", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+
+    // change minterManager to a new token
+    const newTokenConfig = await initializeTokenWithProxy(rawToken);
+    const newToken = newTokenConfig.token;
+    await newToken.updateMasterMinter(mintController.address, {
+      from: Accounts.tokenOwnerAccount,
+    });
+    await mintController.setMinterManager(newToken.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = newToken.address;
+
+    // now use controller to configure and remove minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [newToken, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete010 Change minter manager and make sure existing controllers can increment allowances", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+
+    // change minterManager to a new token
+    const newTokenConfig = await initializeTokenWithProxy(rawToken);
+    const newToken = newTokenConfig.token;
+    await newToken.updateMasterMinter(mintController.address, {
+      from: Accounts.tokenOwnerAccount,
+    });
+    await mintController.setMinterManager(newToken.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = newToken.address;
+
+    // now use controller to configure minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    await mintController.incrementMinterAllowance(20, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(30),
+      }
+    );
+    await checkMINTp0(
+      [newToken, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete011 New controller can increment minter allowance", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(0, {
+      from: Accounts.arbitraryAccount,
+    });
+    await mintController.incrementMinterAllowance(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete012 New controller can remove minter", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete013 Change minter manager, configure a minter, then change back and make sure changes DID NOT propogate", async function () {
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+
+    // change minterManager to a new token
+    const newTokenConfig = await initializeTokenWithProxy(rawToken);
+    const newToken = newTokenConfig.token;
+    await newToken.updateMasterMinter(mintController.address, {
+      from: Accounts.tokenOwnerAccount,
+    });
+    await mintController.setMinterManager(newToken.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = newToken.address;
+
+    // now use controller to configure minter
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(10),
+      }
+    );
+    await checkMINTp0(
+      [newToken, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+
+    // change minterManager to original token and make sure changes did not propagate
+    await mintController.setMinterManager(token.address, {
+      from: Accounts.mintOwnerAccount,
+    });
+    expectedMintControllerState.minterManager = token.address;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: false },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(0),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete014 Remove a minter and then try to increment its allowance reverts", async function () {
+    // add and remove minter
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+
+    // now verify that incrementing its allowance reverts
+    expectError(
+      mintController.incrementMinterAllowance(20, {
+        from: Accounts.arbitraryAccount,
+      }),
+      "Can only increment allowance for minters in minterManager"
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete015 Configure a minter and make sure it can mint", async function () {
+    // configure a minter
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+
+    // now verify it can mint
+    await token.mint(Accounts.arbitraryAccount, 5, {
+      from: Accounts.minterAccount,
+    });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(5),
+      },
+      { variable: "balances.arbitraryAccount", expectedValue: newBigNumber(5) },
+      { variable: "totalSupply", expectedValue: newBigNumber(5) }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete016 Remove a minter and make sure it cannot mint", async function () {
+    // add and remove minter
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+
+    // now verify that minter cannot mint
+    expectRevert(
+      token.mint(Accounts.arbitraryAccount2, 5, {
+        from: Accounts.minterAccount,
+      })
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete017 Configure a minter and make sure it can burn", async function () {
+    // configure a minter
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+
+    // now verify it can burn
+    await token.mint(Accounts.minterAccount, 5, {
+      from: Accounts.minterAccount,
+    });
+    await token.burn(5, { from: Accounts.minterAccount });
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "isAccountMinter.minterAccount", expectedValue: true },
+      {
+        variable: "minterAllowance.minterAccount",
+        expectedValue: newBigNumber(5),
+      }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+
+  it("ete018 Remove a minter and make sure it cannot burn", async function () {
+    // add minter,  use it to mint to itself, and remove it again
+    await mintController.configureController(
+      Accounts.arbitraryAccount,
+      Accounts.minterAccount,
+      { from: Accounts.mintOwnerAccount }
+    );
+    await mintController.configureMinter(10, {
+      from: Accounts.arbitraryAccount,
+    });
+    await token.mint(Accounts.minterAccount, 5, {
+      from: Accounts.minterAccount,
+    });
+    await mintController.removeMinter({ from: Accounts.arbitraryAccount });
+
+    // now verify that minter cannot burn
+    expectRevert(token.burn(5, { from: Accounts.minterAccount }));
+    expectedMintControllerState.controllers.arbitraryAccount =
+      Accounts.minterAccount;
+    expectedTokenState.push(
+      { variable: "balances.minterAccount", expectedValue: newBigNumber(5) },
+      { variable: "totalSupply", expectedValue: newBigNumber(5) }
+    );
+    await checkMINTp0(
+      [token, mintController],
+      [expectedTokenState, expectedMintControllerState]
+    );
+  });
+}
+
+const wrapTests = require("../v1/helpers/wrapTests");
+wrapTests("MINTp0_EndToEndTests MintController", run_tests_MintController);
+wrapTests("MINTp0_EndToEndTests MasterMinter", run_tests_MasterMinter);

--- a/test/v1/helpers/tokenTest.js
+++ b/test/v1/helpers/tokenTest.js
@@ -918,18 +918,6 @@ async function expectRevert(contractPromise) {
   assert.fail("Expected error of type revert, but no error was received");
 }
 
-async function expectJump(contractPromise) {
-  try {
-    await contractPromise;
-    assert.fail("Expected invalid opcode not received");
-  } catch (error) {
-    assert.isTrue(
-      error.message.includes("invalid opcode"),
-      `Expected "invalid opcode", got ${error} instead`
-    );
-  }
-}
-
 function encodeCall(name, args, values) {
   const methodId = abi.methodID(name, args).toString("hex");
   const params = abi.rawEncode(args, values).toString("hex");
@@ -1019,7 +1007,6 @@ module.exports = {
   customInitializeTokenWithProxy,
   upgradeTo,
   expectRevert,
-  expectJump,
   encodeCall,
   getInitializedV1,
   nullAccount,

--- a/yarn.lock
+++ b/yarn.lock
@@ -769,6 +769,14 @@ asn1@~0.2.3:
   dependencies:
     safer-buffer "~2.1.0"
 
+assert-diff@1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/assert-diff/-/assert-diff-1.2.6.tgz#1b44d6f24a7e3018f557768ee350ae9a732c2fc6"
+  integrity sha512-cKyCfCQrLsHubcvDo4n5lGJPxN5gwpm4Hmsjs9/DJCFs4a5jiNvhKRxKP2DZGxNxOf9Iv3pxOoBSCQ+8eiNIKA==
+  dependencies:
+    assert-plus "1.0.0"
+    json-diff "0.5.2"
+
 assert-plus@1.0.0, assert-plus@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
@@ -1778,6 +1786,13 @@ class-is@^1.1.0:
   resolved "https://registry.yarnpkg.com/class-is/-/class-is-1.1.0.tgz#9d3c0fba0440d211d843cec3dedfa48055005825"
   integrity sha512-rhjH9AG1fvabIDoGRVH587413LPjTZgmDF9fOFCbFJQV4yuocX1mHxxvXI4g3cGwbVY9wAYIoKlg1N79frJKQw==
 
+cli-color@~0.1.6:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/cli-color/-/cli-color-0.1.7.tgz#adc3200fa471cc211b0da7f566b71e98b9d67347"
+  integrity sha1-rcMgD6RxzCEbDaf1ZrcemLnWc0c=
+  dependencies:
+    es5-ext "0.8.x"
+
 cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
@@ -2251,6 +2266,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+difflib@~0.2.1:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/difflib/-/difflib-0.2.4.tgz#b5e30361a6db023176d562892db85940a718f47e"
+  integrity sha1-teMDYabbAjF21WKJLbhZQKcY9H4=
+  dependencies:
+    heap ">= 0.2.0"
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
@@ -2298,6 +2320,13 @@ drbg.js@^1.0.1:
     browserify-aes "^1.0.6"
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
+
+dreamopt@~0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/dreamopt/-/dreamopt-0.6.0.tgz#d813ccdac8d39d8ad526775514a13dda664d6b4b"
+  integrity sha1-2BPM2sjTnYrVJndVFKE92mZNa0s=
+  dependencies:
+    wordwrap ">=0.0.2"
 
 duplexer3@^0.1.4:
   version "0.1.4"
@@ -2463,6 +2492,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+es5-ext@0.8.x:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.8.2.tgz#aba8d9e1943a895ac96837a62a39b3f55ecd94ab"
+  integrity sha1-q6jZ4ZQ6iVrJaDemKjmz9V7NlKs=
 
 es5-ext@^0.10.35, es5-ext@^0.10.50:
   version "0.10.53"
@@ -3920,6 +3954,11 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
+"heap@>= 0.2.0":
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/heap/-/heap-0.2.6.tgz#087e1f10b046932fc8594dd9e6d378afc9d1e5ac"
+  integrity sha1-CH4fELBGky/IWU3Z5tN4r8nR5aw=
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -4380,6 +4419,15 @@ json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
   integrity sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
+json-diff@0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/json-diff/-/json-diff-0.5.2.tgz#e0bc9e434cd2c4c6354487835e01bf3fed335cda"
+  integrity sha512-N7oapTQdD4rLMUtA7d1HATCPY/BpHuSNL1mhvIuoS0u5NideDvyR+gB/ntXB7ejFz/LM0XzPLNUJQcC68n5sBw==
+  dependencies:
+    cli-color "~0.1.6"
+    difflib "~0.2.1"
+    dreamopt "~0.6.0"
 
 json-parse-better-errors@^1.0.1:
   version "1.0.2"
@@ -8069,7 +8117,7 @@ word-wrap@^1.2.3, word-wrap@~1.2.3:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
 
-wordwrap@^1.0.0:
+wordwrap@>=0.0.2, wordwrap@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=


### PR DESCRIPTION
1. Upgrades solidity version of the master minter contracts, which were previously kept in https://github.com/centrehq/centre-tokens/tree/multi-issuer, from 0.4.24 to v.0.6.12, to match the rest of the USDC contracts.
2. Updates javascript test structure and syntax to pass the linter (the multi-issuer branch was written before there was a linter, so some javascript cleanup was necessary, but no new solidity changes aside from the version upgrade.)
 
See [masterminter.md](https://github.com/walkerq/centre-tokens-1/blob/98361d4b0e4a75d5aee0e5b6d542e39fb6701360/doc/masterminter.md) for info about the master minter contracts.