### PR TITLE
USDC v3, alternative implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
   },
   "[typescript]": {
     "editor.formatOnSave": true
-  }
+  },
+  "solidity.compileUsingRemoteVersion": "v0.6.12+commit.27d51765"
 }

--- a/contracts/test/UpgradedFiatTokenNewFieldsV3Test.sol
+++ b/contracts/test/UpgradedFiatTokenNewFieldsV3Test.sol
@@ -1,0 +1,76 @@
+/**
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2018 zOS Global Limited.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+pragma solidity 0.6.12;
+
+import { FiatTokenV3 } from "../v3/FiatTokenV3.sol";
+
+/**
+ * @title UpgradedFiatTokenNewFieldsTest
+ * @dev ERC20 Token backed by fiat reserves
+ */
+contract UpgradedFiatTokenNewFieldsV3Test is FiatTokenV3 {
+    bool public newBool;
+    address public newAddress;
+    uint256 public newUint;
+    bool internal initializedV2;
+
+    function initialize(
+        string calldata tokenName,
+        string calldata tokenSymbol,
+        string calldata tokenCurrency,
+        uint8 tokenDecimals,
+        address newMasterMinter,
+        address newPauser,
+        address newBlacklister,
+        address newOwner,
+        bool _newBool,
+        address _newAddress,
+        uint256 _newUint
+    ) external {
+        super.initialize(
+            tokenName,
+            tokenSymbol,
+            tokenCurrency,
+            tokenDecimals,
+            newMasterMinter,
+            newPauser,
+            newBlacklister,
+            newOwner
+        );
+        initV2(_newBool, _newAddress, _newUint);
+    }
+
+    function initV2(
+        bool _newBool,
+        address _newAddress,
+        uint256 _newUint
+    ) public {
+        require(!initializedV2, "contract is already initialized");
+        newBool = _newBool;
+        newAddress = _newAddress;
+        newUint = _newUint;
+        initializedV2 = true;
+    }
+}

--- a/contracts/test/UpgradedFiatTokenV3.sol
+++ b/contracts/test/UpgradedFiatTokenV3.sol
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: MIT
  *
- * Copyright (c) 2018-2020 CENTRE SECZ
+ * Copyright (c) 2018 zOS Global Limited.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,37 +24,12 @@
 
 pragma solidity 0.6.12;
 
-import { FiatTokenV2 } from "./FiatTokenV2.sol";
-
-// solhint-disable func-name-mixedcase
+import { FiatTokenV3 } from "../v3/FiatTokenV3.sol";
 
 /**
- * @title FiatToken V2.1
- * @notice ERC20 Token backed by fiat reserves, version 2.1
+ * @title UpgradedFiatToken
+ * @dev ERC20 Token backed by fiat reserves
  */
-contract FiatTokenV2_1 is FiatTokenV2 {
-    /**
-     * @notice Initialize v2.1
-     * @param lostAndFound  The address to which the locked funds are sent
-     */
-    function initializeV2_1(address lostAndFound) external {
-        // solhint-disable-next-line reason-string
-        require(_initializedVersion == 1);
+contract UpgradedFiatTokenV3 is FiatTokenV3 {
 
-        uint256 lockedAmount = balances[address(this)];
-        if (lockedAmount > 0) {
-            _transfer(address(this), lostAndFound, lockedAmount);
-        }
-        blacklisted[address(this)] = true;
-
-        _initializedVersion = 2;
-    }
-
-    /**
-     * @notice Version string for the EIP712 domain separator
-     * @return Version string
-     */
-    function version() virtual external view returns (string memory) {
-        return "2";
-    }
 }

--- a/contracts/v1/Blacklistable.sol
+++ b/contracts/v1/Blacklistable.sol
@@ -53,7 +53,7 @@ contract Blacklistable is Ownable {
      * @dev Throws if argument account is blacklisted
      * @param _account The address to check
      */
-    modifier notBlacklisted(address _account) {
+    modifier notBlacklisted(address _account) virtual {
         require(
             !blacklisted[_account],
             "Blacklistable: account is blacklisted"
@@ -65,7 +65,7 @@ contract Blacklistable is Ownable {
      * @dev Checks if account is blacklisted
      * @param _account The address to check
      */
-    function isBlacklisted(address _account) external view returns (bool) {
+    function isBlacklisted(address _account) virtual external view returns (bool) {
         return blacklisted[_account];
     }
 
@@ -73,7 +73,7 @@ contract Blacklistable is Ownable {
      * @dev Adds account to blacklist
      * @param _account The address to blacklist
      */
-    function blacklist(address _account) external onlyBlacklister {
+    function blacklist(address _account) virtual external onlyBlacklister {
         blacklisted[_account] = true;
         emit Blacklisted(_account);
     }
@@ -82,7 +82,7 @@ contract Blacklistable is Ownable {
      * @dev Removes account from blacklist
      * @param _account The address to remove from the blacklist
      */
-    function unBlacklist(address _account) external onlyBlacklister {
+    function unBlacklist(address _account) virtual external onlyBlacklister {
         blacklisted[_account] = false;
         emit UnBlacklisted(_account);
     }

--- a/contracts/v1/FiatTokenV1.sol
+++ b/contracts/v1/FiatTokenV1.sol
@@ -190,6 +190,7 @@ contract FiatTokenV1 is AbstractFiatTokenV1, Ownable, Pausable, Blacklistable {
      * @param account address The account
      */
     function balanceOf(address account)
+        virtual
         external
         override
         view
@@ -246,6 +247,7 @@ contract FiatTokenV1 is AbstractFiatTokenV1, Ownable, Pausable, Blacklistable {
         address to,
         uint256 value
     )
+        virtual
         external
         override
         whenNotPaused
@@ -270,6 +272,7 @@ contract FiatTokenV1 is AbstractFiatTokenV1, Ownable, Pausable, Blacklistable {
      * @return True if successful
      */
     function transfer(address to, uint256 value)
+        virtual
         external
         override
         whenNotPaused
@@ -291,7 +294,7 @@ contract FiatTokenV1 is AbstractFiatTokenV1, Ownable, Pausable, Blacklistable {
         address from,
         address to,
         uint256 value
-    ) internal override {
+    ) virtual internal override {
         require(from != address(0), "ERC20: transfer from the zero address");
         require(to != address(0), "ERC20: transfer to the zero address");
         require(

--- a/contracts/v2/FiatTokenV2.sol
+++ b/contracts/v2/FiatTokenV2.sol
@@ -106,7 +106,7 @@ contract FiatTokenV2 is FiatTokenV1_1, EIP3009, EIP2612 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external whenNotPaused notBlacklisted(from) notBlacklisted(to) {
+    ) virtual external whenNotPaused notBlacklisted(from) notBlacklisted(to) {
         _transferWithAuthorization(
             from,
             to,
@@ -144,7 +144,7 @@ contract FiatTokenV2 is FiatTokenV1_1, EIP3009, EIP2612 {
         uint8 v,
         bytes32 r,
         bytes32 s
-    ) external whenNotPaused notBlacklisted(from) notBlacklisted(to) {
+    ) virtual external whenNotPaused notBlacklisted(from) notBlacklisted(to) {
         _receiveWithAuthorization(
             from,
             to,

--- a/contracts/v3/FiatTokenV3.sol
+++ b/contracts/v3/FiatTokenV3.sol
@@ -1,0 +1,272 @@
+/**
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2018-2020 CENTRE SECZ
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+pragma solidity 0.6.12;
+
+import { FiatTokenV2_1 } from "../v2/FiatTokenV2_1.sol";
+import { EIP712 } from "../util/EIP712.sol";
+
+// solhint-disable func-name-mixedcase
+
+/**
+ * @title FiatTokenV3
+ * @dev ERC20 Token backed by fiat reserves
+ */
+contract FiatTokenV3 is FiatTokenV2_1 {
+
+    /**
+     * @notice Initialize v3
+     */
+    function initializeV3() external {
+        require(_initializedVersion == 2, "v3 initialized out of order");
+
+        DOMAIN_SEPARATOR = EIP712.makeDomainSeparator(name, "3");
+
+        _initializedVersion = 3;
+    }
+
+    /**
+     * @dev Adds account to blacklist
+     * @param _account The address to blacklist
+     */
+    function blacklist(address _account) override external onlyBlacklister {
+        balances[_account] = balances[_account] | (uint256(1) << 255);
+        emit Blacklisted(_account);
+    }
+
+    /**
+     * @dev Removes account from blacklist
+     * @param _account The address to remove from the blacklist
+     */
+    function unBlacklist(address _account) override external onlyBlacklister {
+        balances[_account] = balances[_account] & ~(uint256(1) << 255);
+        emit UnBlacklisted(_account);
+    }
+
+    /**
+     * @dev Checks if account is blacklisted
+     * @param _account The address to check
+     */
+    function isBlacklisted(address _account) override external view returns (bool) {
+        return balances[_account] >> 255 == 1;
+    }
+
+    /**
+     * @dev Throws if argument account is blacklisted
+     * @param _account The address to check
+     */
+    modifier notBlacklisted(address _account) override {
+        require(
+            !(balances[_account] >> 255 == 1),
+            "Blacklistable: account is blacklisted"
+        );
+        _;
+    }
+
+    /**
+     * @dev Get token balance of an account
+     * @param account address The account
+     */
+    function balanceOf(address account)
+        external
+        override
+        view
+        returns (uint256)
+    {
+        // return balance without effect of blacklist high bit
+        return balances[account] & ~(uint256(1) << 255);
+    }
+
+    /**
+     * @dev Get token balance of an account
+     * @param account address The account
+     */
+    function _getBalanceAndBlacklistStatus(address account)
+        internal
+        view
+        returns (uint256, bool)
+    {
+        uint256 balance = balances[account];
+        return (balance & ~(uint256(1) << 255), balance >> 255 == 1);
+    }
+
+    /**
+     * @notice Internal function to process transfers
+     * @param from  Payer's address
+     * @param to    Payee's address
+     * @param value Transfer amount
+     */
+    function _transfer(
+        address from,
+        address to,
+        uint256 value
+    ) internal override notBlacklisted(to) {
+        require(from != address(0), "ERC20: transfer from the zero address");
+        require(to != address(0), "ERC20: transfer to the zero address");
+
+        (uint256 fromBalance, bool isFromBlacklisted) = _getBalanceAndBlacklistStatus(from);
+
+        require(!isFromBlacklisted, "Blacklistable: account is blacklisted");
+
+        require(
+            value <= fromBalance,
+            "ERC20: transfer amount exceeds balance"
+        );
+
+        balances[from] = fromBalance.sub(value);
+        balances[to] = balances[to].add(value);
+        emit Transfer(from, to, value);
+    }
+
+    /**
+     * @notice Transfer tokens from the caller
+     * @param to    Payee's address
+     * @param value Transfer amount
+     * @return True if successful
+     */
+    function transfer(address to, uint256 value)
+        external
+        override
+        whenNotPaused
+        returns (bool)
+    {
+        _transfer(msg.sender, to, value);
+        return true;
+    }
+
+    /**
+     * @notice Transfer tokens by spending allowance
+     * @param from  Payer's address
+     * @param to    Payee's address
+     * @param value Transfer amount
+     * @return True if successful
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 value
+    )
+        virtual
+        external
+        override
+        whenNotPaused
+        notBlacklisted(msg.sender)
+        returns (bool)
+    {
+        require(
+            value <= allowed[from][msg.sender],
+            "ERC20: transfer amount exceeds allowance"
+        );
+        _transfer(from, to, value);
+
+        // allow for infinite allowance gas saving trick
+        if (allowed[from][msg.sender] != uint256(-1)) {
+            allowed[from][msg.sender] = allowed[from][msg.sender].sub(value);
+        }
+
+        return true;
+    }
+
+    /**
+     * @notice Execute a transfer with a signed authorization
+     * @param from          Payer's address (Authorizer)
+     * @param to            Payee's address
+     * @param value         Amount to be transferred
+     * @param validAfter    The time after which this is valid (unix time)
+     * @param validBefore   The time before which this is valid (unix time)
+     * @param nonce         Unique nonce
+     * @param v             v of the signature
+     * @param r             r of the signature
+     * @param s             s of the signature
+     */
+    function transferWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) override external whenNotPaused {
+        _transferWithAuthorization(
+            from,
+            to,
+            value,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s
+        );
+    }
+
+    /**
+     * @notice Receive a transfer with a signed authorization from the payer
+     * @dev This has an additional check to ensure that the payee's address
+     * matches the caller of this function to prevent front-running attacks.
+     * @param from          Payer's address (Authorizer)
+     * @param to            Payee's address
+     * @param value         Amount to be transferred
+     * @param validAfter    The time after which this is valid (unix time)
+     * @param validBefore   The time before which this is valid (unix time)
+     * @param nonce         Unique nonce
+     * @param v             v of the signature
+     * @param r             r of the signature
+     * @param s             s of the signature
+     */
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) override external whenNotPaused {
+        _receiveWithAuthorization(
+            from,
+            to,
+            value,
+            validAfter,
+            validBefore,
+            nonce,
+            v,
+            r,
+            s
+        );
+    }
+
+    /**
+     * @notice Version string for the EIP712 domain separator
+     * @return Version string
+     */
+    function version() external override view returns (string memory) {
+        return "3";
+    }
+}

--- a/scripts/gas_usage_v2_vs_v3.js
+++ b/scripts/gas_usage_v2_vs_v3.js
@@ -1,0 +1,113 @@
+// run with `yarn truffle exec scripts/gas_usage_v2_vs_v3.js`
+
+const FiatTokenV2_1 = artifacts.require("FiatTokenV2_1");
+const FiatTokenV3 = artifacts.require("FiatTokenV3");
+
+module.exports = async function (callback) {
+  try {
+    const [fiatTokenOwner, alice, bob] = await web3.eth.getAccounts();
+    const mintAmount = 50e6;
+    const transferAmount = 10e6;
+
+    const fiatTokenV3 = await initializeV3(fiatTokenOwner);
+    const fiatTokenV2_1 = await initializeV2_1(fiatTokenOwner);
+
+    await fiatTokenV3.mint(alice, mintAmount, { from: fiatTokenOwner });
+    const transferTxV3 = await fiatTokenV3.transfer(bob, transferAmount, {
+      from: alice,
+    });
+    console.log("V3 transfer gas usage:", transferTxV3.receipt.gasUsed);
+
+    await fiatTokenV2_1.mint(alice, mintAmount, {
+      from: fiatTokenOwner,
+    });
+    const transferTxV2_1 = await fiatTokenV2_1.transfer(bob, transferAmount, {
+      from: alice,
+    });
+    console.log("V2.1 transfer gas usage:", transferTxV2_1.receipt.gasUsed);
+
+    const approvalTxV3 = await fiatTokenV3.approve(bob, transferAmount, {
+      from: alice,
+    });
+    console.log("V3 approve gas usage:", approvalTxV3.receipt.gasUsed);
+
+    const approvalTxV2_1 = await fiatTokenV2_1.approve(bob, transferAmount, {
+      from: alice,
+    });
+    console.log("V2.1 approve gas usage:", approvalTxV2_1.receipt.gasUsed);
+
+    const transferFromTxV3 = await fiatTokenV3.transferFrom(
+      alice,
+      bob,
+      transferAmount,
+      {
+        from: bob,
+      }
+    );
+    console.log("V3 transferFrom gas usage:", transferFromTxV3.receipt.gasUsed);
+
+    const transferFromTxV2_1 = await fiatTokenV2_1.transferFrom(
+      alice,
+      bob,
+      transferAmount,
+      {
+        from: bob,
+      }
+    );
+    console.log(
+      "V2.1 transferFrom gas usage:",
+      transferFromTxV2_1.receipt.gasUsed
+    );
+  } catch (error) {
+    console.log(error);
+  }
+
+  callback();
+};
+
+async function initializeV3(fiatTokenOwner) {
+  const fiatTokenV3 = await FiatTokenV3.new();
+
+  await fiatTokenV3.initialize(
+    "USD Coin",
+    "USDC",
+    "USD",
+    6,
+    fiatTokenOwner,
+    fiatTokenOwner,
+    fiatTokenOwner,
+    fiatTokenOwner
+  );
+  await fiatTokenV3.initializeV2("USD Coin", { from: fiatTokenOwner });
+  await fiatTokenV3.initializeV2_1(fiatTokenOwner, { from: fiatTokenOwner });
+  await fiatTokenV3.initializeV3({ from: fiatTokenOwner });
+
+  await fiatTokenV3.configureMinter(fiatTokenOwner, 1000000e6, {
+    from: fiatTokenOwner,
+  });
+
+  return fiatTokenV3;
+}
+
+async function initializeV2_1(fiatTokenOwner) {
+  const fiatTokenV2_1 = await FiatTokenV2_1.new();
+
+  await fiatTokenV2_1.initialize(
+    "USD Coin",
+    "USDC",
+    "USD",
+    6,
+    fiatTokenOwner,
+    fiatTokenOwner,
+    fiatTokenOwner,
+    fiatTokenOwner
+  );
+  await fiatTokenV2_1.initializeV2("USD Coin", { from: fiatTokenOwner });
+  await fiatTokenV2_1.initializeV2_1(fiatTokenOwner, { from: fiatTokenOwner });
+
+  await fiatTokenV2_1.configureMinter(fiatTokenOwner, 1000000e6, {
+    from: fiatTokenOwner,
+  });
+
+  return fiatTokenV2_1;
+}

--- a/test/helpers/storageSlots.behavior.ts
+++ b/test/helpers/storageSlots.behavior.ts
@@ -13,7 +13,7 @@ export function usesOriginalStorageSlotPositions<
   accounts,
 }: {
   Contract: Truffle.Contract<T>;
-  version: 1 | 1.1 | 2 | 2.1;
+  version: 1 | 1.1 | 2 | 2.1 | 3;
   accounts: Truffle.Accounts;
 }): void {
   describe("uses original storage slot positions", () => {
@@ -134,19 +134,39 @@ export function usesOriginalStorageSlotPositions<
     }
 
     it("retains original storage slots for blacklisted mapping", async () => {
-      // blacklisted[alice]
-      let v = parseInt(
-        await readSlot(proxy.address, addressMappingSlot(alice, 3)),
-        16
-      );
-      expect(v).to.equal(0);
+      if (version < 3) {
+        // blacklisted[alice]
+        let v = parseInt(
+          await readSlot(proxy.address, addressMappingSlot(alice, 3)),
+          16
+        );
+        expect(v).to.equal(0);
 
-      // blacklisted[charlie]
-      v = parseInt(
-        await readSlot(proxy.address, addressMappingSlot(charlie, 3)),
-        16
-      );
-      expect(v).to.equal(1);
+        // blacklisted[charlie]
+        v = parseInt(
+          await readSlot(proxy.address, addressMappingSlot(charlie, 3)),
+          16
+        );
+        expect(v).to.equal(1);
+      } else {
+        // balances[alice] high bit
+        let v = parseInt(
+          await readSlot(proxy.address, addressMappingSlot(alice, 9)),
+          16
+        )
+          .toString(2)
+          .padStart(256, "0")[0];
+        expect(v).to.equal("0");
+
+        // balances[charlie] high bit
+        v = parseInt(
+          await readSlot(proxy.address, addressMappingSlot(charlie, 9)),
+          16
+        )
+          .toString(2)
+          .padStart(256, "0")[0];
+        expect(v).to.equal("1");
+      }
     });
 
     it("retains original storage slots for balances mapping", async () => {

--- a/test/minting/MintP0_ArgumentTests.js
+++ b/test/minting/MintP0_ArgumentTests.js
@@ -22,11 +22,11 @@ const zeroAddress = "0x0000000000000000000000000000000000000000";
 const maxAmount =
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-async function run_tests_MintController(newToken, accounts) {
+async function run_tests_MintController(newToken, accounts, _version) {
   run_MINT_tests(newToken, MintController, accounts);
 }
 
-async function run_tests_MasterMinter(newToken, accounts) {
+async function run_tests_MasterMinter(newToken, accounts, _version) {
   run_MINT_tests(newToken, MasterMinter, accounts);
 }
 

--- a/test/minting/MintP0_BasicTests.js
+++ b/test/minting/MintP0_BasicTests.js
@@ -22,11 +22,11 @@ const initializeTokenWithProxyAndMintController =
 
 const zeroAddress = "0x0000000000000000000000000000000000000000";
 
-async function run_tests_MintController(newToken, accounts) {
+async function run_tests_MintController(newToken, accounts, _version) {
   run_MINT_tests(newToken, MintController, accounts);
 }
 
-async function run_tests_MasterMinter(newToken, accounts) {
+async function run_tests_MasterMinter(newToken, accounts, _version) {
   run_MINT_tests(newToken, MasterMinter, accounts);
 }
 

--- a/test/minting/MintP0_EndToEndTests.js
+++ b/test/minting/MintP0_EndToEndTests.js
@@ -23,11 +23,11 @@ let token;
 let rawToken;
 let tokenConfig;
 
-async function run_tests_MintController(newToken, accounts) {
+async function run_tests_MintController(newToken, accounts, _version) {
   run_MINT_tests(newToken, MintController, accounts);
 }
 
-async function run_tests_MasterMinter(newToken, accounts) {
+async function run_tests_MasterMinter(newToken, accounts, _version) {
   run_MINT_tests(newToken, MasterMinter, accounts);
 }
 

--- a/test/minting/MintP0_EventsTests.js
+++ b/test/minting/MintP0_EventsTests.js
@@ -23,11 +23,11 @@ const mintControllerEvents = {
   minterAllowanceDecremented: "MinterAllowanceDecremented",
 };
 
-async function run_tests_MintController(newToken, accounts) {
+async function run_tests_MintController(newToken, accounts, _version) {
   run_MINT_tests(newToken, MintController, accounts);
 }
 
-async function run_tests_MasterMinter(newToken, accounts) {
+async function run_tests_MasterMinter(newToken, accounts, _version) {
   run_MINT_tests(newToken, MasterMinter, accounts);
 }
 

--- a/test/v1/abiHacking.test.js
+++ b/test/v1/abiHacking.test.js
@@ -26,7 +26,7 @@ function mockStringAddressEncode(methodName, address) {
   return functionSignature(methodName) + version + encodeAddress(address);
 }
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let proxy, token;
 
   beforeEach(async () => {

--- a/test/v1/events.test.js
+++ b/test/v1/events.test.js
@@ -32,7 +32,7 @@ const {
 
 const amount = 100;
 
-function runTests(_newToken, _accounts) {
+function runTests(_newToken, _accounts, _version) {
   let proxy, token;
 
   beforeEach(async () => {

--- a/test/v1/extendedPositive.test.js
+++ b/test/v1/extendedPositive.test.js
@@ -11,12 +11,13 @@ const {
   pauserAccount,
   initializeTokenWithProxy,
   UpgradedFiatToken,
+  UpgradedFiatTokenV3,
   upgradeTo,
 } = require("./helpers/tokenTest");
 
 const amount = 100;
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let proxy, token;
 
   beforeEach(async () => {
@@ -248,7 +249,13 @@ function runTests(newToken, _accounts) {
 
   it("ept022 should upgrade when msg.sender blacklisted", async () => {
     await token.blacklist(upgraderAccount, { from: blacklisterAccount });
-    const newRawToken = await UpgradedFiatToken.new();
+    let newRawToken;
+    if (_version < 3) {
+      newRawToken = await UpgradedFiatToken.new();
+    } else {
+      newRawToken = await UpgradedFiatTokenV3.new();
+    }
+
     const tokenConfig = await upgradeTo(proxy, newRawToken);
     const newProxiedToken = tokenConfig.token;
 
@@ -260,7 +267,12 @@ function runTests(newToken, _accounts) {
   });
 
   it("ept023 should upgrade to blacklisted address", async () => {
-    const newRawToken = await UpgradedFiatToken.new();
+    let newRawToken;
+    if (_version < 3) {
+      newRawToken = await UpgradedFiatToken.new();
+    } else {
+      newRawToken = await UpgradedFiatTokenV3.new();
+    }
 
     await token.blacklist(newRawToken.address, { from: blacklisterAccount });
     const tokenConfig = await upgradeTo(proxy, newRawToken);

--- a/test/v1/helpers/tokenTest.js
+++ b/test/v1/helpers/tokenTest.js
@@ -6,8 +6,12 @@ const Q = require("q");
 
 const FiatTokenV1 = artifacts.require("FiatTokenV1");
 const UpgradedFiatToken = artifacts.require("UpgradedFiatToken");
+const UpgradedFiatTokenV3 = artifacts.require("UpgradedFiatTokenV3");
 const UpgradedFiatTokenNewFields = artifacts.require(
   "UpgradedFiatTokenNewFieldsTest"
+);
+const UpgradedFiatTokenNewFieldsV3 = artifacts.require(
+  "UpgradedFiatTokenNewFieldsV3Test"
 );
 const UpgradedFiatTokenNewFieldsNewLogic = artifacts.require(
   "UpgradedFiatTokenNewFieldsNewLogicTest"
@@ -963,7 +967,9 @@ module.exports = {
   FiatTokenV1,
   FiatTokenProxy,
   UpgradedFiatToken,
+  UpgradedFiatTokenV3,
   UpgradedFiatTokenNewFields,
+  UpgradedFiatTokenNewFieldsV3,
   UpgradedFiatTokenNewFieldsNewLogic,
   name,
   symbol,

--- a/test/v1/helpers/wrapTests.js
+++ b/test/v1/helpers/wrapTests.js
@@ -1,6 +1,7 @@
 const FiatTokenV1 = artifacts.require("FiatTokenV1");
 const FiatTokenV1_1 = artifacts.require("FiatTokenV1_1");
 const FiatTokenV2 = artifacts.require("FiatTokenV2");
+const FiatTokenV3 = artifacts.require("FiatTokenV3");
 
 // The following helpers make fresh original/upgraded tokens before each test.
 
@@ -16,19 +17,27 @@ function newFiatTokenV2() {
   return FiatTokenV2.new();
 }
 
+function newFiatTokenV3() {
+  return FiatTokenV3.new();
+}
+
 // Executes the run_tests_function using an original and
 // an upgraded token. The test_suite_name is printed standard output.
 function wrapTests(testSuiteName, runTestsFunction) {
   contract(`FiatTokenV1: ${testSuiteName}`, (accounts) => {
-    runTestsFunction(newFiatTokenV1, accounts);
+    runTestsFunction(newFiatTokenV1, accounts, 1);
   });
 
   contract(`FiatTokenV1_1: ${testSuiteName}`, (accounts) => {
-    runTestsFunction(newFiatTokenV1_1, accounts);
+    runTestsFunction(newFiatTokenV1_1, accounts, 1.1);
   });
 
   contract(`FiatTokenV2: ${testSuiteName}`, (accounts) => {
-    runTestsFunction(newFiatTokenV2, accounts);
+    runTestsFunction(newFiatTokenV2, accounts, 2);
+  });
+
+  contract(`FiatTokenV3: ${testSuiteName}`, (accounts) => {
+    runTestsFunction(newFiatTokenV3, accounts, 3);
   });
 }
 

--- a/test/v1/legacy.test.js
+++ b/test/v1/legacy.test.js
@@ -745,4 +745,6 @@ function runTests(_newToken, accounts) {
   });
 }
 
+// NOTE: these tests are run for each version but just
+// use the v1 contract each time
 wrapTests("legacy", runTests);

--- a/test/v1/misc.test.js
+++ b/test/v1/misc.test.js
@@ -15,12 +15,14 @@ const {
   FiatTokenProxy,
 } = require("./helpers/tokenTest");
 
+// When using the high bit for blacklisting, 2^255 is the max
+// usable amount
 const maxAmount =
-  "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
+  "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 const maxAmountBN = new BN(maxAmount.slice(2), 16);
 const amount = 100;
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let proxy, token;
 
   beforeEach(async () => {
@@ -722,7 +724,7 @@ function runTests(newToken, _accounts) {
     assert.strictEqual("0x00", initialized);
   });
 
-  it("ms047 configureMinter works on amount=2^256-1", async () => {
+  it("ms047 configureMinter works on amount=2^255-1", async () => {
     await token.configureMinter(minterAccount, maxAmount, {
       from: masterMinterAccount,
     });
@@ -736,7 +738,7 @@ function runTests(newToken, _accounts) {
     await checkVariables([token], [customVars]);
   });
 
-  it("ms048 mint works on amount=2^256-1", async () => {
+  it("ms048 mint works on amount=2^255-1", async () => {
     await token.configureMinter(minterAccount, maxAmount, {
       from: masterMinterAccount,
     });
@@ -765,7 +767,7 @@ function runTests(newToken, _accounts) {
     await checkVariables([token], [customVars]);
   });
 
-  it("ms049 burn on works on amount=2^256-1", async () => {
+  it("ms049 burn on works on amount=2^255-1", async () => {
     await token.configureMinter(minterAccount, maxAmount, {
       from: masterMinterAccount,
     });
@@ -787,7 +789,7 @@ function runTests(newToken, _accounts) {
     await checkVariables([token], [customVars]);
   });
 
-  it("ms050 approve works on amount=2^256-1", async () => {
+  it("ms050 approve works on amount=2^255-1", async () => {
     await token.configureMinter(minterAccount, maxAmount, {
       from: masterMinterAccount,
     });
@@ -818,7 +820,7 @@ function runTests(newToken, _accounts) {
     await checkVariables([token], [customVars]);
   });
 
-  it("ms051 transfer works on amount=2^256-1", async () => {
+  it("ms051 transfer works on amount=2^255-1", async () => {
     await token.configureMinter(minterAccount, maxAmount, {
       from: masterMinterAccount,
     });
@@ -845,7 +847,7 @@ function runTests(newToken, _accounts) {
     await checkVariables([token], [customVars]);
   });
 
-  it("ms052 transferFrom works on amount=2^256-1", async () => {
+  it("ms052 transferFrom works on amount=2^255-1", async () => {
     await token.configureMinter(minterAccount, maxAmount, {
       from: masterMinterAccount,
     });

--- a/test/v1/negative.test.js
+++ b/test/v1/negative.test.js
@@ -19,7 +19,7 @@ const {
 
 const amount = 100;
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let proxy, token;
 
   beforeEach(async () => {

--- a/test/v1/positive.test.js
+++ b/test/v1/positive.test.js
@@ -14,7 +14,7 @@ const {
 
 const amount = 100;
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let proxy, token;
 
   beforeEach(async () => {

--- a/test/v1/proxyNegative.test.js
+++ b/test/v1/proxyNegative.test.js
@@ -25,7 +25,7 @@ const {
 
 const amount = 100;
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let rawToken, proxy, token;
 
   beforeEach(async () => {

--- a/test/v1/proxyPositive.test.js
+++ b/test/v1/proxyPositive.test.js
@@ -23,6 +23,7 @@ const {
   FiatTokenProxy,
   UpgradedFiatToken,
   UpgradedFiatTokenNewFields,
+  UpgradedFiatTokenNewFieldsV3,
   UpgradedFiatTokenNewFieldsNewLogic,
   getAdmin,
 } = require("./helpers/tokenTest");
@@ -30,7 +31,7 @@ const { makeRawTransaction, sendRawTransaction } = require("./helpers/abi");
 
 const amount = 100;
 
-function runTests(newToken, _accounts) {
+function runTests(newToken, _accounts, _version) {
   let rawToken, proxy, token;
 
   beforeEach(async () => {
@@ -405,7 +406,12 @@ function runTests(newToken, _accounts) {
   it("upt012 should upgradeToAndCall while upgrader is blacklisted", async () => {
     await token.blacklist(proxyOwnerAccount, { from: blacklisterAccount });
 
-    const upgradedToken = await UpgradedFiatTokenNewFields.new();
+    let upgradedToken;
+    if (_version < 3) {
+      upgradedToken = await UpgradedFiatTokenNewFields.new();
+    } else {
+      upgradedToken = await UpgradedFiatTokenNewFieldsV3.new();
+    }
     const initializeData = encodeCall(
       "initV2",
       ["bool", "address", "uint256"],

--- a/test/v3/FiatTokenV3.test.ts
+++ b/test/v3/FiatTokenV3.test.ts
@@ -1,0 +1,112 @@
+import BN from "bn.js";
+
+import { FiatTokenV3Instance } from "../../@types/generated";
+import { usesOriginalStorageSlotPositions } from "../helpers/storageSlots.behavior";
+import { expectRevert } from "../helpers";
+import { makeDomainSeparator } from "../v2/GasAbstraction/helpers";
+import { MAX_UINT256 } from "../helpers/constants";
+import { assert } from "chai";
+
+const FiatTokenV3 = artifacts.require("FiatTokenV3");
+
+contract("FiatTokenV3", (accounts) => {
+  const fiatTokenOwner = accounts[0];
+  const blacklister = accounts[4];
+  let fiatToken: FiatTokenV3Instance;
+  const lostAndFound = accounts[2];
+  const mintable = 1000000e6;
+  const infiniteAllower = accounts[10];
+  const infiniteSpender = accounts[11];
+
+  beforeEach(async () => {
+    fiatToken = await FiatTokenV3.new();
+    await fiatToken.initialize(
+      "USD Coin",
+      "USDC",
+      "USD",
+      6,
+      fiatTokenOwner,
+      fiatTokenOwner,
+      blacklister,
+      fiatTokenOwner
+    );
+    await fiatToken.initializeV2("USD Coin", { from: fiatTokenOwner });
+    await fiatToken.initializeV2_1(lostAndFound, { from: fiatTokenOwner });
+    await fiatToken.initializeV3({ from: fiatTokenOwner });
+
+    await fiatToken.configureMinter(fiatTokenOwner, mintable, {
+      from: fiatTokenOwner,
+    });
+  });
+
+  behavesLikeFiatTokenV3(
+    accounts,
+    () => fiatToken,
+    fiatTokenOwner,
+    infiniteAllower,
+    infiniteSpender
+  );
+});
+
+export function behavesLikeFiatTokenV3(
+  accounts: Truffle.Accounts,
+  getFiatToken: () => FiatTokenV3Instance,
+  fiatTokenOwner: string,
+  infiniteAllower: string,
+  infiniteSpender: string
+): void {
+  usesOriginalStorageSlotPositions({
+    Contract: FiatTokenV3,
+    version: 3,
+    accounts,
+  });
+
+  it("has the expected domain separator", async () => {
+    const expectedDomainSeparator = makeDomainSeparator(
+      "USD Coin",
+      "3",
+      1, // hardcoded to 1 because of ganache bug: https://github.com/trufflesuite/ganache/issues/1643
+      getFiatToken().address
+    );
+    expect(await getFiatToken().DOMAIN_SEPARATOR()).to.equal(
+      expectedDomainSeparator
+    );
+  });
+
+  it("it allows user to set and remove an infinite allowance", async () => {
+    const maxAllowanceBN = new BN(MAX_UINT256.slice(2), 16);
+    const zeroBN = new BN(0);
+
+    await getFiatToken().mint(infiniteAllower, 100e6, {
+      from: fiatTokenOwner,
+    });
+
+    await getFiatToken().approve(infiniteSpender, MAX_UINT256, {
+      from: infiniteAllower,
+    });
+
+    // spend allower's balance
+    await getFiatToken().transferFrom(infiniteAllower, infiniteSpender, 50e6, {
+      from: infiniteSpender,
+    });
+
+    const allowance1 = await getFiatToken().allowance(
+      infiniteAllower,
+      infiniteSpender
+    );
+    assert.isTrue(allowance1.eq(maxAllowanceBN));
+
+    // revoke approval
+    await getFiatToken().approve(infiniteSpender, 0, { from: infiniteAllower });
+    const allowance2 = await getFiatToken().allowance(
+      infiniteAllower,
+      infiniteSpender
+    );
+    assert.isTrue(allowance2.eq(zeroBN));
+  });
+
+  it("disallows calling initializeV3 twice", async () => {
+    // It was called once in beforeEach. Try to call again.
+    await expectRevert(getFiatToken().initializeV3({ from: fiatTokenOwner }));
+  });
+}


### PR DESCRIPTION
This PR is an alternative USDC v3 implementation. Unlike https://github.com/centrehq/centre-tokens/pull/338, it does not change any functionality of USDC, but accomplishes similar gas savings by stuffing the `blacklist` boolean into the high bit of a user's balance.

Check out this [post](https://alexkroeger.mirror.xyz/RJ1gZ8tAfqXOmfA3MJz0AkD082c-3hwr2lba-F1j3uw) on mirror.xyz for more context about why it's worth trying to save on gas for checking the blacklist.

Tasks:
- [ ] Modify blacklist by storing the boolean in the high bit of the user's balance
- [ ] Implement the "infinite allowance" hack for bonus gas savings (see https://twitter.com/philipliao_/status/1479860204577693700?s=20 for context)
- [ ] Ensure all legacy tests are still working with the proposed changes
- [ ] Test infinite allowance hack
- [ ] Write migration script that ensures that existing blacklisted users have the high bit boolean set